### PR TITLE
fix: execute the release version check as one Python program

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,12 @@ jobs:
       - name: Require v<project.version> release tag
         shell: bash
         run: |
-          version=$(python -c \
-            "import tomllib; "\
-            "project=tomllib.load(open('pyproject.toml', 'rb')); "\
-            "print(project['project']['version'])")
+          version=$(python -c '
+          import tomllib
+          with open("pyproject.toml", "rb") as stream:
+              project = tomllib.load(stream)
+          print(project["project"]["version"])
+          ')
           expected="v${version}"
           if [[ "$GITHUB_REF_NAME" != "$expected" ]]; then
             echo "Release tag mismatch: expected $expected;" \


### PR DESCRIPTION
## Summary

The v1.0.0 release run exposed a shell quoting bug: the multiline `python -c` invocation passed the program as three arguments, so Python executed only `import tomllib` and the version appeared empty. This change passes one multiline Python program and preserves the exact tag/version gate.

## Validation

- reproduced the failed argument splitting locally
- corrected command resolves `1.0.0`
- 36 documentation and artifact-policy tests passed

The failed release did not build or publish any artifacts; all downstream jobs were skipped.