### PR TITLE
fix: strip native rebuild sources from Windows wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 from setuptools import setup  # type: ignore[import-untyped]
+from setuptools.command.build_py import build_py  # type: ignore[import-untyped]
 
 
 def _boost_paths() -> tuple[list[str], list[str]]:
@@ -26,6 +27,25 @@ def _boost_paths() -> tuple[list[str], list[str]]:
             )
             return [str(Path(candidate, "include"))], library_dirs
     return [], []
+
+
+class PortableBuildPy(build_py):
+    """Remove native rebuild sources from wheels on every host platform."""
+
+    _source_suffixes = frozenset({".cpp", ".h", ".cu", ".mm", ".metal"})
+
+    @classmethod
+    def remove_native_sources(cls, package_root: Path) -> None:
+        """Delete source-only native files copied into a wheel build tree."""
+        if not package_root.is_dir():
+            return
+        for path in package_root.rglob("*"):
+            if path.is_file() and path.suffix.lower() in cls._source_suffixes:
+                path.unlink()
+
+    def run(self) -> None:
+        super().run()
+        self.remove_native_sources(Path(self.build_lib) / "treemendous")
 
 
 class PortableBuildExt(build_ext):
@@ -112,7 +132,10 @@ def make_cpu_extensions() -> list[Pybind11Extension]:
 def run_setup() -> None:
     setup(
         ext_modules=make_cpu_extensions(),
-        cmdclass={"build_ext": PortableBuildExt},
+        cmdclass={
+            "build_ext": PortableBuildExt,
+            "build_py": PortableBuildPy,
+        },
         zip_safe=False,
     )
 

--- a/tests/packaging/test_artifact_policy.py
+++ b/tests/packaging/test_artifact_policy.py
@@ -20,6 +20,7 @@ from scripts.verify_artifact_contents import (
     verify_sdist,
     verify_wheel,
 )
+from setup import PortableBuildPy
 
 pytestmark = pytest.mark.packaging
 
@@ -157,6 +158,29 @@ def test_directory_inputs_filter_hidden_non_artifacts(tmp_path: Path) -> None:
     _sdist(artifact, REQUIRED_SDIST)
     (tmp_path / ".gitignore").write_text("*\n", encoding="utf-8")
     assert artifact_paths([tmp_path]) == [artifact]
+
+
+def test_portable_wheel_build_removes_native_sources_cross_platform(
+    tmp_path: Path,
+) -> None:
+    package_root = tmp_path / "treemendous"
+    native_root = package_root / "cpp" / "metal"
+    native_root.mkdir(parents=True)
+    source_names = {
+        "binding.cpp",
+        "header.h",
+        "kernel.cu",
+        "backend.mm",
+        "shader.metal",
+    }
+    retained_names = {"module.py", "extension.pyd", "shader.metallib"}
+    for name in source_names | retained_names:
+        (native_root / name).write_text("input", encoding="utf-8")
+
+    PortableBuildPy.remove_native_sources(package_root)
+
+    assert not any((native_root / name).exists() for name in source_names)
+    assert all((native_root / name).is_file() for name in retained_names)
 
 
 def _run_cuda_setup(cuda_home: Path) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
## Summary

The v1.0.0 release matrix exposed a Windows-specific setuptools behavior: extension binding sources from `SOURCES.txt` were copied into Windows wheel build trees even though `exclude-package-data` excluded them on Linux and macOS. Artifact verification correctly rejected all three Windows wheels.

This adds a cross-platform `build_py` command that removes native rebuild-only source files from the wheel build tree after Python package files are copied and before wheel assembly. Source distributions remain unchanged and retain every required rebuild input.

## Validation

- reproduced the release failure on all Windows Python lanes
- new build helper preserves `.py`, `.pyd`, and `.metallib` files while removing `.cpp`, `.h`, `.cu`, `.mm`, and `.metal`
- 31 artifact-policy tests passed
- a fresh local wheel passed artifact verification and contained no native sources

The failed release did not reach aggregate verification or the PyPI publisher.