### PR TITLE
fix: pin the PyPI publisher's dereferenced commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -203,6 +203,6 @@ jobs:
           path: dist
       # pypa/gh-action-pypi-publish v1.13.0
       - uses: >-
-          pypa/gh-action-pypi-publish@106e0b0b7c337fa67ed433972f777c6357f78598
+          pypa/gh-action-pypi-publish@ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e
         with:
           packages-dir: dist

--- a/tests/docs/test_readme.py
+++ b/tests/docs/test_readme.py
@@ -100,6 +100,10 @@ def test_release_tag_contract_tracks_the_releasable_major_version() -> None:
     workflow = (ROOT / ".github/workflows/release.yml").read_text()
     assert 'expected="v${version}"' in workflow
     assert 'GITHUB_REF_NAME" != "$expected' in workflow
+    # v1.13.0 is an annotated tag. Pin the dereferenced commit whose matching
+    # GHCR image exists, not the tag-object SHA that yields `manifest unknown`.
+    assert "ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e" in workflow
+    assert "106e0b0b7c337fa67ed433972f777c6357f78598" not in workflow
     assert 'version = "1.0.0"' in (ROOT / "pyproject.toml").read_text()
 
 


### PR DESCRIPTION
## Summary

The release publisher used the SHA of the annotated `v1.13.0` tag object (`106e0b0…`). The action generated a GHCR image reference from that SHA, but PyPA publishes the image under the dereferenced commit SHA, so Docker returned `manifest unknown`.

This pins the dereferenced `v1.13.0^{}` commit (`ed0c539…`) and adds a regression assertion documenting why the tag-object SHA must not return.

## Evidence

- `git ls-remote` confirms `v1.13.0^{}` resolves to `ed0c53931b1dc9bd32cbe73a98c7f6766f8a527e`
- all release artifacts aggregated and verified before the publisher step
- no artifact reached PyPI
- focused release-contract test passed