### PR TITLE
perf: qualify range and index roadmap experiments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ __pycache__/
 *.so
 compile_commands.json
 
+# Generated benchmark/experiment evidence (reproduced locally or attached as
+# release assets, never committed to source).
+docs/evidence/
+
 # Distribution / packaging
 .Python
 build/

--- a/Justfile
+++ b/Justfile
@@ -63,6 +63,104 @@ benchmark-smoke output="build/benchmarks/smoke.json": build-cpp
 benchmark-standard output="build/benchmarks/standard.json": build-cpp
     uv run python -m tests.performance.benchmark_suite --profile standard --require-all-stable --output "{{output}}"
 
+# Compare two explicitly supplied native roots. The shipped checkout remains on
+# vector storage, so there is deliberately no current-tree candidate default.
+experiment-exact-batch-storage-matrix baseline_root candidate_root output="build/experiments/exact-batch-storage-matrix.json": install-dev
+    uv run python -m tests.performance.experiments.exact_batch_storage_matrix \
+        --baseline-root "{{baseline_root}}" \
+        --candidate-root "{{candidate_root}}" \
+        --blocks 20 \
+        --output "{{output}}"
+
+verify-exact-batch-storage-matrix artifact="build/experiments/exact-batch-storage-matrix.json": install-dev
+    uv run python -m tests.performance.experiments.exact_batch_storage_matrix \
+        --verify \
+        --output "{{artifact}}"
+
+verify-exact-batch-storage-archive artifact="docs/evidence/experiments/exact-batch-storage-segmented-tuned-rejection.json": install-dev
+    uv run python -m tests.performance.experiments.exact_batch_storage_matrix \
+        --verify \
+        --archive \
+        --output "{{artifact}}"
+
+# Intentionally expensive: two detached builds plus the historical 20-block smoke.
+reproduce-exact-batch-storage-rejection output="build/experiments/exact-batch-storage-segmented-reproduced.json": install-dev
+    scripts/reproduce_exact_batch_storage_rejection.sh "{{output}}"
+
+# Bounded diagnostic only; this does not replace any stable exact-batch gate.
+experiment-exact-batch-application-matrix profile="smoke" output="build/experiments/exact-batch-application-matrix.json": build-cpp
+    uv run python -m tests.performance.experiments.exact_batch_application_matrix \
+        --profile "{{profile}}" \
+        --samples 10 \
+        --output "{{output}}"
+
+verify-exact-batch-application-matrix artifact="build/experiments/exact-batch-application-matrix.json": install-dev
+    uv run python -m tests.performance.experiments.exact_batch_application_matrix \
+        --verify \
+        --output "{{artifact}}"
+
+# Private RangeSet transaction candidate; "full" omits --bounded.
+experiment-rangeset-transaction profile="bounded" output="build/experiments/rangeset-transaction.json": install-dev
+    #!/usr/bin/env bash
+    set -euo pipefail
+    bounded=()
+    if [[ "{{profile}}" == "bounded" ]]; then
+        bounded+=(--bounded)
+    elif [[ "{{profile}}" != "full" ]]; then
+        echo "profile must be bounded or full" >&2
+        exit 2
+    fi
+    uv run python -m tests.performance.experiments.rangeset_transaction \
+        --samples 15 \
+        --output "{{output}}" \
+        "${bounded[@]}"
+
+verify-rangeset-transaction artifact="build/experiments/rangeset-transaction.json": install-dev
+    uv run python -m tests.performance.experiments.rangeset_transaction \
+        --verify \
+        --output "{{artifact}}"
+
+experiment-rangeset-snapshot-scaling output="build/experiments/rangeset-snapshot-scaling.json": install-dev
+    uv run python -m tests.performance.experiments.rangeset_snapshot_scaling \
+        --blocks 40 \
+        --output "{{output}}"
+
+verify-rangeset-snapshot-scaling artifact="build/experiments/rangeset-snapshot-scaling.json": install-dev
+    uv run python -m tests.performance.experiments.rangeset_snapshot_scaling \
+        --verify \
+        --output "{{artifact}}"
+
+# Experimental concrete-application qualification; never changes runtime selection.
+experiment-application-backend-matrix output="build/experiments/application-backend-matrix.json": build-cpp
+    uv run python -m tests.performance.experiments.application_backend_matrix \
+        --blocks 20 \
+        --output "{{output}}"
+
+verify-application-backend-matrix artifact="build/experiments/application-backend-matrix.json": install-dev
+    uv run python -m tests.performance.experiments.application_backend_matrix \
+        --verify \
+        --output "{{artifact}}"
+
+experiment-lease-state-scaling blocks="30" output="build/experiments/lease-state-scaling.json": install-dev
+    uv run python -m tests.performance.experiments.lease_state_scaling \
+        --blocks "{{blocks}}" \
+        --output "{{output}}"
+
+verify-lease-state-scaling artifact="build/experiments/lease-state-scaling.json": install-dev
+    uv run python -m tests.performance.experiments.lease_state_scaling \
+        --verify \
+        --output "{{artifact}}"
+
+# Experiment-only RadioSpectrumScheduler index injection; runtime remains linear
+# unless every fixed training, memory, and held-out gate passes.
+experiment-radio-spectrum-index-matrix output="build/experiments/radio-spectrum-index-matrix.json" timeout_seconds="3600": install-dev
+    uv run python -c 'import subprocess, sys; subprocess.run([sys.executable, "-m", "tests.performance.experiments.radio_spectrum_index_matrix", "--profile", "full", "--blocks", "25", "--output", "{{output}}"], check=True, timeout=int("{{timeout_seconds}}"))'
+
+verify-radio-spectrum-index-matrix artifact="build/experiments/radio-spectrum-index-matrix.json": install-dev
+    uv run python -m tests.performance.experiments.radio_spectrum_index_matrix \
+        --verify \
+        --output "{{artifact}}"
+
 benchmark-attribution baseline_root candidate_root="." output="build/benchmarks/mutation-attribution.json": install-dev
     uv run python -m tests.performance.mutation_attribution \
         --baseline-root "{{baseline_root}}" \

--- a/docs/application-patterns.md
+++ b/docs/application-patterns.md
@@ -4,6 +4,24 @@ Tree-Mendous exposes reusable primitives and 50 concrete process-local engines.
 A pattern shows how a primitive can fit inside a larger design; it is not a new
 registered engine and does not add the surrounding service guarantees.
 
+## Pattern catalog
+
+| Pattern | Primitive | Geometry represented | Required external semantics |
+| --- | --- | --- | --- |
+| [Port-pool reconciliation](../examples/patterns/atomic_port_pool_reconciliation.py) | `ExactBatchRangeSet` | Free port spans | Lease identity, TTL, fencing, persistence, coordination |
+| [Memory-map updates](../examples/patterns/atomic_memory_map_updates.py) | `ExactBatchRangeSet` | Mapped address spans | Mapping identity, page/protection rules, OS publication, recovery |
+| [Partition availability](../examples/patterns/atomic_partition_availability_updates.py) | `ExactBatchRangeSet` | Available partition-number spans | Partition generations, replica health, quorum, durable catalog |
+| [Genomic mask updates](../examples/patterns/genomic_mask_batch_updates.py) | `ExactBatchRangeSet` | Masked coordinate spans | Build/contig identity, strand/features, conversion, provenance |
+| [Spatiotemporal geofences](../examples/patterns/spatiotemporal_geofences.py) | experimental `BoxIndex3D` | x/y/time boxes | Coordinate reference system, polygons, authorization, durability |
+| [Warehouse reservations](../examples/patterns/warehouse_space_time_reservations.py) | experimental `BoxIndex3D` | x/y/time occupancy boxes | Map/units, routing, vehicle geometry, booking coordination |
+| [Video region timeline](../examples/patterns/video_region_timeline_overlap.py) | experimental `BoxIndex3D` | x/y/time media boxes | Timebase, codec/pixel semantics, track identity, edit persistence |
+| [Robot volume-time conflicts](../examples/patterns/robot_volume_time_conflicts.py) | experimental `BoxIndex4D` | x/y/z/time broad-phase boxes | Continuous motion, rotation, collision physics, planning |
+
+All eight are executable, self-asserting examples outside the 50-engine
+registry. The exact-batch patterns use ordered geometry rows and explicit
+`BatchLimits`; the box patterns preserve owner-scoped duplicate identity and
+deterministic insertion order where records share geometry.
+
 ## Atomic geometry reconciliation
 
 Use `ExactBatchRangeSet` when a controller has already decided which integer
@@ -75,9 +93,9 @@ the generic multidimensional index:
   two-dimensional cells into one-dimensional Morton bands for candidate
   selection, then apply exact Cartesian filtering.
 
-The new `BoxIndex3D` prototype is outside the registry and does not inherit the
-radio scheduler's reservation semantics or the Morton catalog's filtering
-contract.
+The `BoxIndex3D` and `BoxIndex4D` patterns are outside the registry and do not
+inherit the radio scheduler's reservation semantics or the Morton catalog's
+filtering contract.
 
 ## Combining primitives safely
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -217,6 +217,264 @@ not publish an operations-per-second headline: throughput is derived only from
 measured elapsed time and the declared operation count in the artifact. Native
 attribution is not a mandatory scheduled parent-commit promotion gate.
 
+## Segmented ExactBatch storage qualification
+
+The Phase G2 storage experiment compared the immutable vector baseline at
+commit `2a384f7` with the now-rejected segmented candidate in isolated
+subprocesses. The durable proof of the rejection is the tracked patch
+`tests/performance/experiments/fixtures/exact_batch_segmented_tuned.patch` plus
+its pinned SHAs: applying it to the baseline `exact_batch_bindings.cpp` at
+`2a384f7` reproduces the segmented source SHA-256
+`f5a368f011bcbbe9f49ba954b7014268ab7c711ecfb1d46b8b4d9da6a8858267`. That patch
+chain is checked unconditionally by the storage experiment test suite and does
+not depend on any measured artifact.
+
+The measured 20-block tuned-smoke triplet is reproducible evidence, not tracked
+source: like every other benchmark artifact it lives under the ignored
+`build/`/`docs/evidence/` output tree or is attached as a release asset. Once a
+copy exists at
+`docs/evidence/experiments/exact-batch-storage-segmented-tuned-rejection.json`
+(with its Markdown and `.json.sha256` sidecars), verify it offline without the
+historical binaries:
+
+```bash
+just verify-exact-batch-storage-archive
+```
+
+The archive binds baseline commit/source/binary hashes, candidate binary and
+runtime provenance, the exact reconstructed patch SHA-256, and the resulting
+segmented `exact_batch_bindings.cpp` SHA-256.
+Verification reapplies the patch to the baseline source from Git and strictly
+reconstructs worker schemas, all scalar-oracle digests, raw block ratios,
+bootstrap summaries, matrix order, and the rejected 1.10 small-N gate. It does
+not require the rolled-back package to expose segmented counters. The
+archive-data contracts in the test suite skip automatically when no such copy is
+present.
+
+To reproduce rather than verify, use the intentionally expensive recipe below.
+It creates two detached temporary worktrees at the baseline commit, applies and
+hash-checks the patch only in the candidate, builds distinct binaries, invokes
+the fixed smoke harness for 20 balanced blocks, and removes both worktrees on
+exit:
+
+```bash
+just reproduce-exact-batch-storage-rejection \
+  build/experiments/exact-batch-storage-segmented-reproduced.json
+```
+
+The fixed matrix covers N={64,1000,10000,100000}, B={0,1,16,256}, local,
+strict-only, duplicate-only, 1/10/100%-width, and K-1/K/K+1 block-boundary
+cells. Twenty fixed blocks alternate which isolated root process runs first.
+Each process measures the complete promotion matrix; bootstrap intervals
+resample whole block ratios. Setup, canonical `cpp_boundary` replay, packed
+result materialization, final snapshots, counter inspection, RSS, and artifact
+writing are outside mutation timers. Construction, mutation, snapshot, and
+materialization are separate cells.
+
+The verifier requires canonical JSON plus matching Markdown and SHA-256,
+rejects duplicate keys and non-finite values, reconstructs matrix identity and
+every ratio/bootstrap/gate derivation, and recomputes source, runtime, compiler,
+and native-binary provenance. The pre-registered gates are not adjusted after
+measurement. A failed required gate rejects the segmented runtime rather than
+weakening a threshold. The sole small-N tuning confirmation was rejected: its
+20-block N64/B16 candidate/vector median was 1.065273 and its upper-95 bound was
+1.115916, above the unchanged 1.10 gate. The package therefore retains vector
+storage and does not expose the segmented counters or failpoints.
+
+## Experimental exact-batch application matrix
+
+The first roadmap experiment is a correctness-attested diagnostic under
+`tests/performance/experiments`; it is not stable package code and does not
+change the existing exact-batch gates. A bounded smoke run is:
+
+```bash
+just experiment-exact-batch-application-matrix smoke \
+  build/experiments/exact-batch-application-smoke.json
+just verify-exact-batch-application-matrix \
+  build/experiments/exact-batch-application-smoke.json
+```
+
+The complete local profile uses at least 10 paired raw samples for every cell
+across batch sizes 1, 4, 16, and 64; pre-call live state counts 64, 1,000, and
+10,000; head/middle/tail locality; and strict accept/reject, idempotent
+real/no-op, fragment/restore, coalesce/restore, and eight-span fan-out shapes:
+
+```bash
+just experiment-exact-batch-application-matrix local \
+  build/experiments/exact-batch-application-local.json
+```
+
+The 100,000-state slice is manual and explicitly opt-in:
+
+```bash
+uv run python -m tests.performance.experiments.exact_batch_application_matrix \
+  --profile local --include-100000 --samples 10 \
+  --output build/experiments/exact-batch-application-100000.json
+```
+
+Manager/domain setup, operation packing, scalar-oracle construction, result
+materialization, snapshots, validation, and artifact writing are outside both
+timers. Each paired sample alternates packed-first/scalar-first order. Every
+packed row and final state is checked against scalar `cpp_boundary` replay.
+The JSON records raw packed/scalar samples, paired ratios, bootstrap median
+intervals, packed input/result bytes, exact declared work, workload digest, and
+source/build/environment provenance; Markdown and SHA-256 companions bind the
+report.
+
+Interpret observed median break-even only for the named state, shape, locality,
+machine, build, and timed layers. A confidence interval crossing 1.0 is
+inconclusive. A local dirty-worktree artifact remains useful for diagnosis but
+is not promotion evidence. This experiment makes no universal performance
+claim and leaves the stable v3/v1 gates and their workflows unchanged.
+
+## Experimental payload-aware RangeSet transaction
+
+The private `tests.performance.experiments.rangeset_transaction` prototype
+copies complete geometry, payload, and ordered-event state to a fresh proven
+catalog backend, replays ordered scalar mutations, and publishes only after all
+fallible work succeeds. It adds no `RangeSet` method or stable protocol. Run the
+short diagnostic or the complete B={0,1,4,16,64}, N={64,1000}, four-policy,
+two-trace matrix with:
+
+```bash
+just experiment-rangeset-transaction bounded \
+  build/experiments/rangeset-transaction-bounded.json
+just experiment-rangeset-transaction full \
+  build/experiments/rangeset-transaction-full.json
+just verify-rangeset-transaction \
+  build/experiments/rangeset-transaction-full.json
+```
+
+Every cell alternates transaction/scalar order for at least 15 paired samples;
+setup and exact same-instance result/final-state validation remain outside the
+timers. `tracemalloc` is inactive for both latency paths; peak memory comes from
+a separate untimed transaction replay that is also validated against the scalar
+oracle. The canonical JSON/Markdown/SHA-256 triplet records raw total, staging,
+backend-load, memory, interval, resource, source, and backend provenance. Fixed
+gates require B16/N1000 upper-95 ratios at most 1.00 for every payload, one
+non-restorative upper-95 ratio at most 0.90, and no nonempty cell above 1.10.
+Failure marks the experiment `REJECTED`; it is not a reason to weaken a gate or
+promote the candidate into the stable package.
+
+## Experimental geometry snapshot cache
+
+The stable `RangeSet` reuses one exact immutable `RangeSnapshot` only for an
+unchanged geometry-only state. Payload-bearing snapshots retain their existing
+clone-and-detach behavior. The E4-A scaling experiment compares public cached
+`snapshot()` with faithful uncached `RangeSnapshot` construction on the same
+state. Setup and same-instance validation remain outside retained-block timing:
+
+```bash
+just experiment-rangeset-snapshot-scaling \
+  build/experiments/rangeset-snapshot-scaling.json
+just verify-rangeset-snapshot-scaling \
+  build/experiments/rangeset-snapshot-scaling.json
+```
+
+The pre-registered N={100,1000,10000} confirmation matrix uses exactly 40
+balanced blocks, not sample-until-pass collection. Every retained block contains
+both a cached-first and an uncached-first ordering; the ordering-pair sequence is
+reversed in alternating blocks. Cached elapsed time is totaled across its two
+positions, uncached elapsed time is totaled across its two positions, and one
+ratio is then derived for the whole block. Bootstrap 95% median intervals
+resample whole blocks, never pooled individual calls. Unchanged 16-read bursts
+use the same balanced-block analysis as restorative write-then-observe cycles.
+
+Each timed position repeats one common number of cached or uncached iterations.
+An excluded pilot starts at two iterations and doubles until both position
+durations reach at least 5 ms or the deterministic 64-iteration cap. The JSON
+records every pilot duration, the selected count, every raw position and block
+total, and the derivations. Pilot observations never enter samples, bootstrap
+intervals, or gates. Fixed acceptance gates remain unchanged: the N=10000
+unchanged upper-95 cached/uncached ratio must be at most 0.25, the cached
+N=10000/N=1000 per-iteration median ratio at most 1.50, and every
+write-then-observe upper-95 ratio at most 1.10. Canonical JSON, Markdown, and
+SHA-256 artifacts bind exact-type verification plus source, worktree, runtime,
+and backend-binary provenance.
+
+This balanced-block protocol corrects an order-confounding defect in the prior
+pooled single-call analysis. The earlier artifact treated AB and BA calls as
+exchangeable despite a strong order effect and is invalidated; it is not
+confirmation evidence for accepting or rejecting the cache.
+
+## Lease-state publication scaling
+
+The E4-B/D lease-state experiment writes a canonical JSON/Markdown/SHA-256
+triplet and supports generation and verification as distinct commands:
+
+```bash
+just experiment-lease-state-scaling 30 \
+  build/experiments/lease-state-scaling.json
+just verify-lease-state-scaling \
+  build/experiments/lease-state-scaling.json
+```
+
+The fixed matrix is the ordered Cartesian product of four workload kinds and
+N={128,512,2048,8192}. The verifier requires exact per-kind schemas and JSON
+types, recomputes every balanced block total, ratio, bootstrap summary, gate,
+semantic result/final-state digest, fixed instrumentation count, and retained
+memory settling ratio, and binds current source/runtime provenance. Generation
+performs semantic validation and digest construction outside timing. The
+verifier rejects noncanonical bytes, duplicate keys or matrix rows, relabeling,
+missing fields, and numeric bool/int coercion.
+
+## Experimental radio-spectrum index representation
+
+The E6 experiment injects `BoxIndex2D` axis projection and a guarded
+`BoundedBoxIndex` into an empty, real `RadioSpectrumScheduler` only from the
+performance harness. The stable scheduler constructor remains unchanged and
+continues to construct linear `BoxIndex(2)`. Run the fixed matrix with an
+explicit one-hour subprocess timeout, then independently verify its artifact:
+
+```bash
+just experiment-radio-spectrum-index-matrix \
+  build/experiments/radio-spectrum-index-matrix.json 3600
+just verify-radio-spectrum-index-matrix \
+  build/experiments/radio-spectrum-index-matrix.json
+```
+
+The training sizes are 32, 128, 512, 2,000, and 10,000 active entries. Separate
+deterministic held-out sizes are 64, 256, 1,000, and 5,000. Five workload cells
+cover materially different low, medium, and high-overlap seed/query geometry;
+narrow and broad channel/time queries; 3:1, 2:2, and 1:3
+insertion/cancellation call mixes; and balanced, channel, time, and dual-axis
+skew. The fifth, separately named `idempotent-replay` cell measures replay and
+is not counted as any insertion/cancellation mix. Timed mix insertions use
+distinct request IDs and reservations, and cancellations target distinct live
+handles; any live-handle preparation is untimed and independently replayed.
+Every timed position contains eight real scheduler operations. Twenty-five
+fixed AB/BA blocks are recorded before the run, and bootstrap intervals
+resample whole blocks. Construction, seeding, preparation, independent-oracle
+replay, exact same-instance validation, snapshots, diagnostics,
+candidate/posting observations, retained-graph memory, and the RSS high-water
+proxy remain outside operation timers.
+
+The sparse grid is constructed only with explicit finite channel/time bounds,
+cell sizes, and all resource guards. A broad-query adversary deliberately
+exceeds `max_cells_per_query`; its `ValueError` must propagate with unchanged
+state and no catch-and-fallback behavior. Correctness evidence also covers
+reservation and conflict results, duplicate request identity and idempotency,
+cancellation, snapshot order/version, diagnostic algorithm, and exact final
+state against an independent sorted-list radio oracle and the linear scheduler.
+
+Fixed gates are not tuned by a run. A representation needs upper-95 latency
+ratio at most 0.80 at two adjacent training sizes; its crossover is the lower
+size in that passing adjacent pair. Every selected crossover must have at least
+one predetermined held-out size at or above the crossover, and empty held-out
+evidence fails qualification. A policy may select only training cells at most
+0.90; every applicable selected held-out cell must also be at most 0.90. A
+balanced raw-block control separately measures the untouched default scheduler
+against an explicitly injected linear `BoxIndex(2)` and requires an upper-95
+ratio at most 1.10. Selected retained memory must be at most 1.25 times linear.
+There is no live migration. Failure to pass every gate retains no scheduler
+factory seam and leaves runtime linear. The prior full artifact predates this
+v2 protocol and is marked stale; it is not qualification evidence. The strict
+canonical JSON/Markdown/SHA-256 verifier reconstructs exact Cartesian
+membership and order and rejects row relabeling or duplication, duplicate keys,
+non-finite numbers, exact-type changes, query-diagnostic derivation or final
+state digest tampering, decision tampering, and source/runtime/backend
+provenance drift.
+
 ## Exact-batch evidence
 
 The stable specialized exact whole-batch module has a separate path-filtered

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -141,3 +141,23 @@ This is a staged roadmap, not functionality delivered by 1.1.1:
 
 No speculative runtime, storage, snapshot, or application-integration change is
 part of the 1.1.1 documentation and metadata patch.
+
+## Experimental concrete-application backend qualification
+
+The Phase D experiment routes the private factories used by the contiguous and
+disk allocators, scoped lease pools, claim ledger, and partition runtime through
+the semantically probed backend registry. It exercises construction and every
+checkpoint/rebuild/restore path without changing public constructors or stable
+runtime selection. Run the bounded matrix and then independently verify its
+canonical JSON, Markdown, checksum, derivations, and provenance:
+
+```bash
+just experiment-application-backend-matrix
+just verify-application-backend-matrix
+```
+
+The command evaluates every locally available stable deterministic signed-64
+CORE backend against `py_boundary`, uses 20 balanced paired blocks per cell,
+and records fail-closed evidence for ineligible requests. A `REJECTED` result is
+expected evidence, not a command failure; no application backend injection is
+retained unless all fixed initial and confirmation gates pass.

--- a/docs/theory/one_dimensional_interval_algorithms.md
+++ b/docs/theory/one_dimensional_interval_algorithms.md
@@ -269,10 +269,11 @@ Fallback backends and payload-bearing sets retain the immutable Python geometry
 cache. Bisect locates a local change in `O(log n)`, but publishing a successful
 fallback mutation copies tuple references around the changed slice, which is
 `Theta(n)`. The fallback preserves one common semantic implementation for
-payload algebra and for backends without exact deltas. `snapshot()` is a
-separate cost: `RangeSnapshot.__post_init__` currently recomputes the interval
-sum, so every snapshot is `Theta(n)` even when the tuple cache was already
-valid.
+payload algebra and for backends without exact deltas. For geometry-only state,
+the first `snapshot()` materialization is `Theta(n)` and the exact immutable
+value is then cached, making unchanged snapshots `Theta(1)`. A changed state
+must materialize a new `Theta(n)` snapshot. Payload snapshots remain `Theta(n)`
+plus cloning cost and are never identity-reused.
 
 The stable C++ boundary backend also accepts the normalized managed domain at
 construction. It validates geometry mutations and overlap queries against that

--- a/docs/theory/one_dimensional_interval_formal_model.md
+++ b/docs/theory/one_dimensional_interval_formal_model.md
@@ -304,9 +304,11 @@ The patch rebuilds only changed `IntervalResult` objects, but tuple slicing and
 unpacking still copy or scan `Theta(n)` references. Payload-bearing sets use the
 payload path rather than this authoritative geometry state machine.
 
-`snapshot()` is distinct from cached `intervals()`. `RangeSnapshot.__post_init__`
-currently sums every interval to validate `total_free`, so every snapshot costs
-`Theta(n)` even when it reuses a valid tuple.
+`snapshot()` is distinct from cached `intervals()`. The first geometry-only
+snapshot for a state costs `Theta(n)` because `RangeSnapshot.__post_init__` sums
+every interval; unchanged calls then return that exact cached immutable value in
+`Theta(1)`. A changed state's first snapshot and every payload-bearing snapshot
+remain `Theta(n)` (plus payload cloning where applicable).
 
 The transition and enumeration claims are executed in
 `test_one_dimensional_publication.py` without timing assertions.

--- a/examples/README.md
+++ b/examples/README.md
@@ -54,16 +54,38 @@ uv run python examples/exact_batch.py
 These examples are independently executable patterns, not additions to the 50
 registered engines:
 
+Geometry-only `ExactBatchRangeSet` transactions, each with explicit limits and
+exact assertions:
+
 - [`patterns/atomic_port_pool_reconciliation.py`](patterns/atomic_port_pool_reconciliation.py)
-  uses `ExactBatchRangeSet` for one geometry-only transaction. It has no lease
-  identity, TTL, fencing, persistence, or cross-process coordination.
+  keeps lease identity, TTL, fencing, persistence, and coordination external.
+- [`patterns/atomic_memory_map_updates.py`](patterns/atomic_memory_map_updates.py)
+  keeps mapping identity, page/protection rules, OS publication, and recovery external.
+- [`patterns/atomic_partition_availability_updates.py`](patterns/atomic_partition_availability_updates.py)
+  keeps partition identity, replica health, quorum, fencing, and durable catalogs external.
+- [`patterns/genomic_mask_batch_updates.py`](patterns/genomic_mask_batch_updates.py)
+  keeps build/contig identity, genomic metadata, coordinate conversion, and provenance external.
+
+Experimental process-local multidimensional indexes:
+
 - [`patterns/spatiotemporal_geofences.py`](patterns/spatiotemporal_geofences.py)
-  uses experimental, process-local `BoxIndex3D`. It supplies no geographic
-  coordinate system, durability, distribution, or authorization.
+  supplies no geographic coordinate system, durability, distribution, or authorization.
+- [`patterns/warehouse_space_time_reservations.py`](patterns/warehouse_space_time_reservations.py)
+  supplies no warehouse map, routing, vehicle geometry, durable booking, or coordination.
+- [`patterns/video_region_timeline_overlap.py`](patterns/video_region_timeline_overlap.py)
+  supplies no media timebase, codec/pixel semantics, track identity, or edit persistence.
+- [`patterns/robot_volume_time_conflicts.py`](patterns/robot_volume_time_conflicts.py)
+  supplies broad-phase boxes, not continuous motion, rotation, collision physics, or planning.
 
 ```bash
 uv run python examples/patterns/atomic_port_pool_reconciliation.py
+uv run python examples/patterns/atomic_memory_map_updates.py
+uv run python examples/patterns/atomic_partition_availability_updates.py
+uv run python examples/patterns/genomic_mask_batch_updates.py
 uv run python examples/patterns/spatiotemporal_geofences.py
+uv run python examples/patterns/warehouse_space_time_reservations.py
+uv run python examples/patterns/video_region_timeline_overlap.py
+uv run python examples/patterns/robot_volume_time_conflicts.py
 ```
 
 See [Application patterns](../docs/application-patterns.md) for the surrounding
@@ -82,8 +104,8 @@ uv run python examples/multidimensional/core/linear_box_index.py
 The registered radio-spectrum engine wraps experimental `BoxIndex(2)` behind
 its application-specific channel/time reservation contract. The Morton
 geospatial example does not use `BoxIndex`; it uses one-dimensional Morton
-bands plus exact Cartesian filtering. The new `BoxIndex3D` pattern remains
-outside the 50-engine registry.
+bands plus exact Cartesian filtering. All reusable pattern examples above
+remain outside the 50-engine registry.
 
 Backend implementation modules remain internal. Applications should construct
 one-dimensional range sets through `treemendous.create_range_set`, import the

--- a/examples/patterns/atomic_memory_map_updates.py
+++ b/examples/patterns/atomic_memory_map_updates.py
@@ -1,0 +1,52 @@
+"""Apply atomic memory-map geometry updates without mapping identity or OS calls.
+
+This pattern is outside the 50-engine registry. It supplies ordered half-open
+signed-integer geometry only; a real memory manager must provide mapping
+identity, page-size/alignment and protection semantics, persistence or a WAL,
+and operating-system publication and recovery.
+"""
+
+from treemendous import MutationResult, Span
+from treemendous.exact_batch import (
+    BatchLimits,
+    BatchMutation,
+    ExactBatchRangeSet,
+    MutationOpcode,
+)
+
+
+def main() -> None:
+    limits = BatchLimits(
+        max_operations=4,
+        max_live_intervals=4,
+        max_changed_spans=8,
+        max_result_bytes=2_048,
+        max_work_units=32,
+    )
+    mapped = ExactBatchRangeSet(
+        (-4_096, 8_192), initially_available=False, limits=limits
+    )
+    results = mapped.mutate(
+        (
+            BatchMutation(MutationOpcode.ADD, -4_096, -2_048),
+            BatchMutation(MutationOpcode.ADD, 0, 4_096),
+            BatchMutation(MutationOpcode.DISCARD_REQUIRE_COVERED, 1_024, 2_048),
+            BatchMutation(MutationOpcode.ADD, 1_024, 2_048),
+        )
+    )
+
+    assert results == (
+        MutationResult((Span(-4_096, -2_048),), 2_048, False),
+        MutationResult((Span(0, 4_096),), 4_096, False),
+        MutationResult((Span(1_024, 2_048),), 1_024, True),
+        MutationResult((Span(1_024, 2_048),), 1_024, False),
+    )
+    assert tuple(
+        (interval.start, interval.end) for interval in mapped.snapshot().intervals
+    ) == ((-4_096, -2_048), (0, 4_096))
+    assert mapped.limits is limits
+    print("mapped=-4096:-2048,0:4096 changed=2048,4096,1024,1024")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/patterns/atomic_partition_availability_updates.py
+++ b/examples/patterns/atomic_partition_availability_updates.py
@@ -1,0 +1,48 @@
+"""Publish ordered partition-availability geometry as one atomic batch.
+
+This pattern is outside the 50-engine registry. It has no partition identity,
+replica-health or quorum model, generation/fencing semantics, durable catalog,
+or distributed reconciliation protocol; those domain and persistence services
+must remain external.
+"""
+
+from treemendous import MutationResult, Span
+from treemendous.exact_batch import (
+    BatchLimits,
+    BatchMutation,
+    ExactBatchRangeSet,
+    MutationOpcode,
+)
+
+
+def main() -> None:
+    limits = BatchLimits(
+        max_operations=3,
+        max_live_intervals=4,
+        max_changed_spans=6,
+        max_result_bytes=2_048,
+        max_work_units=24,
+    )
+    available = ExactBatchRangeSet(((0, 4), (8, 16)), limits=limits)
+    results = available.mutate(
+        (
+            BatchMutation(MutationOpcode.DISCARD_REQUIRE_COVERED, 2, 4),
+            BatchMutation(MutationOpcode.DISCARD_REQUIRE_COVERED, 10, 14),
+            BatchMutation(MutationOpcode.ADD, 12, 16),
+        )
+    )
+
+    assert results == (
+        MutationResult((Span(2, 4),), 2, True),
+        MutationResult((Span(10, 14),), 4, True),
+        MutationResult((Span(12, 14),), 2, False),
+    )
+    assert tuple(
+        (interval.start, interval.end) for interval in available.snapshot().intervals
+    ) == ((0, 2), (8, 10), (12, 16))
+    assert available.limits is limits
+    print("available=0:2,8:10,12:16 changed=2,4,2")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/patterns/genomic_mask_batch_updates.py
+++ b/examples/patterns/genomic_mask_batch_updates.py
@@ -1,0 +1,49 @@
+"""Update genomic mask geometry atomically without genomic record semantics.
+
+This pattern is outside the 50-engine registry. Coordinates are only half-open
+signed integers: contig/build identity, strand and feature metadata, coordinate
+conversion, durable provenance, validation, and persistence are not supplied.
+"""
+
+from treemendous import MutationResult, Span
+from treemendous.exact_batch import (
+    BatchLimits,
+    BatchMutation,
+    ExactBatchRangeSet,
+    MutationOpcode,
+)
+
+
+def main() -> None:
+    limits = BatchLimits(
+        max_operations=4,
+        max_live_intervals=4,
+        max_changed_spans=8,
+        max_result_bytes=2_048,
+        max_work_units=32,
+    )
+    masks = ExactBatchRangeSet((0, 1_000), initially_available=False, limits=limits)
+    results = masks.mutate(
+        (
+            BatchMutation(MutationOpcode.ADD, 100, 140),
+            BatchMutation(MutationOpcode.ADD, 120, 180),
+            BatchMutation(MutationOpcode.DISCARD_REQUIRE_COVERED, 130, 150),
+            BatchMutation(MutationOpcode.ADD, 130, 150),
+        )
+    )
+
+    assert results == (
+        MutationResult((Span(100, 140),), 40, False),
+        MutationResult((Span(140, 180),), 40, False),
+        MutationResult((Span(130, 150),), 20, True),
+        MutationResult((Span(130, 150),), 20, False),
+    )
+    assert tuple(
+        (interval.start, interval.end) for interval in masks.snapshot().intervals
+    ) == ((100, 180),)
+    assert masks.limits is limits
+    print("masks=100:180 changed=40,40,20,20")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/patterns/robot_volume_time_conflicts.py
+++ b/examples/patterns/robot_volume_time_conflicts.py
@@ -1,0 +1,32 @@
+"""Find broad-phase robot volume-time conflicts in a local 4D index.
+
+``BoxIndex4D`` is experimental and process-local. Its axis-aligned integer
+boxes do not supply robot/trajectory identity, continuous motion or rotation,
+narrow-phase collision geometry, uncertainty margins, planning, durability, or
+multi-controller coordination.
+"""
+
+from treemendous.multidimensional import Box, BoxIndex4D
+
+
+def main() -> None:
+    plans = BoxIndex4D()
+    sweep = Box((-2, -2, 0, 50), (2, 2, 4, 70))
+    arm_a = plans.insert(sweep, "arm-a")
+    arm_b = plans.insert(sweep, "arm-b")
+    after = plans.insert(Box((-2, -2, 0, 70), (2, 2, 4, 90)), "arm-c")
+
+    probe = Box((-1, -1, 1, 60), (1, 1, 2, 61))
+    conflicts = plans.overlaps(probe)
+    assert tuple(entry.handle for entry in conflicts) == (arm_a, arm_b)
+    assert tuple(entry.data for entry in conflicts) == ("arm-a", "arm-b")
+    assert plans.overlaps(Box((-1, -1, 1, 70), (1, 1, 2, 71))) == (plans.get(after),)
+    moved = plans.update(arm_b, box=Box((8, 8, 0, 50), (12, 12, 4, 70)))
+    assert moved.handle == arm_b
+    assert tuple(entry.handle for entry in plans.overlaps(probe)) == (arm_a,)
+    assert plans.remove(arm_a).data == "arm-a"
+    print("conflicts=arm-a,arm-b handles=1,2,3 moved=2 remaining=2,3")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/patterns/video_region_timeline_overlap.py
+++ b/examples/patterns/video_region_timeline_overlap.py
@@ -1,0 +1,35 @@
+"""Query experimental process-local video regions over a timeline.
+
+``BoxIndex3D`` treats x, y, and time as half-open integer axes. It supplies no
+frame-rate/timebase conversion, pixel/codec semantics, polygon masks, track
+identity, media persistence, edit history, or distributed collaboration.
+"""
+
+from treemendous.multidimensional import Box, BoxIndex3D
+
+
+def main() -> None:
+    regions = BoxIndex3D()
+    duplicate = Box((10, 10, 1_000), (30, 30, 1_100))
+    title = regions.insert(duplicate, "title")
+    duplicate_title = regions.insert(duplicate, "title-copy")
+    later = regions.insert(Box((10, 10, 1_100), (30, 30, 1_200)), "later")
+
+    query = Box((20, 20, 1_050), (21, 21, 1_060))
+    matches = regions.overlaps(query)
+    assert tuple(entry.handle for entry in matches) == (title, duplicate_title)
+    assert tuple(entry.data for entry in matches) == ("title", "title-copy")
+    assert regions.overlaps(Box((20, 20, 1_100), (21, 21, 1_101))) == (
+        regions.get(later),
+    )
+    regions.update(duplicate_title, data="title-copy-reviewed")
+    assert regions.remove(title).data == "title"
+    assert tuple(entry.data for entry in regions.entries()) == (
+        "title-copy-reviewed",
+        "later",
+    )
+    print("matches=title,title-copy order=1,2 touching=later remaining=2,3")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/patterns/warehouse_space_time_reservations.py
+++ b/examples/patterns/warehouse_space_time_reservations.py
@@ -1,0 +1,33 @@
+"""Index experimental process-local warehouse space-time reservations.
+
+``BoxIndex3D`` supplies only half-open axis-aligned integer boxes and local
+record identity. It does not supply warehouse units/maps, aisle or vehicle
+geometry, routing, authorization, durable reservations, or coordination.
+"""
+
+from treemendous.multidimensional import Box, BoxIndex3D
+
+
+def main() -> None:
+    reservations = BoxIndex3D()
+    duplicate = Box((0, 0, 100), (4, 4, 120))
+    first = reservations.insert(duplicate, "forklift-a")
+    second = reservations.insert(duplicate, "forklift-b")
+    touching = reservations.insert(Box((4, 0, 100), (8, 4, 120)), "forklift-c")
+
+    query = Box((1, 1, 110), (2, 2, 111))
+    assert tuple(entry.data for entry in reservations.overlaps(query)) == (
+        "forklift-a",
+        "forklift-b",
+    )
+    assert not duplicate.overlaps(Box((4, 0, 100), (5, 1, 101)))
+    removed = reservations.remove(second)
+    updated = reservations.update(first, data="forklift-a-confirmed")
+    assert removed.data == "forklift-b"
+    assert updated.data == "forklift-a-confirmed"
+    assert tuple(entry.handle for entry in reservations.entries()) == (first, touching)
+    print("conflicts=forklift-a,forklift-b handles=1,2,3 remaining=1,3")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/reproduce_exact_batch_storage_rejection.sh
+++ b/scripts/reproduce_exact_batch_storage_rejection.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# Rebuild the historical vector/segmented N64 smoke comparison from source.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON="${PYTHON:-$ROOT/.venv/bin/python}"
+OUTPUT="${1:-$ROOT/build/experiments/exact-batch-storage-segmented-reproduced.json}"
+if [[ "$OUTPUT" != /* ]]; then
+    OUTPUT="$PWD/$OUTPUT"
+fi
+BASELINE_COMMIT="2a384f74d29949fefd0286a147b30c1ef0a190d4"
+EXPECTED_SOURCE_SHA256="f5a368f011bcbbe9f49ba954b7014268ab7c711ecfb1d46b8b4d9da6a8858267"
+PATCH="$ROOT/tests/performance/experiments/fixtures/exact_batch_segmented_tuned.patch"
+
+if [[ ! -x "$PYTHON" ]]; then
+    echo "Python interpreter is not executable: $PYTHON" >&2
+    exit 2
+fi
+
+TEMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/treemendous-storage-reproduction.XXXXXX")"
+BASELINE="$TEMP_ROOT/baseline"
+CANDIDATE="$TEMP_ROOT/candidate"
+cleanup() {
+    set +e
+    git -C "$ROOT" worktree remove --force "$CANDIDATE" >/dev/null 2>&1
+    git -C "$ROOT" worktree remove --force "$BASELINE" >/dev/null 2>&1
+    rm -rf "$TEMP_ROOT"
+}
+trap cleanup EXIT INT TERM
+
+git -C "$ROOT" worktree add --detach "$BASELINE" "$BASELINE_COMMIT"
+git -C "$ROOT" worktree add --detach "$CANDIDATE" "$BASELINE_COMMIT"
+git -C "$CANDIDATE" apply "$PATCH"
+
+ACTUAL_SOURCE_SHA256="$($PYTHON - "$CANDIDATE/treemendous/cpp/exact_batch_bindings.cpp" <<'PY'
+import hashlib
+import sys
+from pathlib import Path
+print(hashlib.sha256(Path(sys.argv[1]).read_bytes()).hexdigest())
+PY
+)"
+if [[ "$ACTUAL_SOURCE_SHA256" != "$EXPECTED_SOURCE_SHA256" ]]; then
+    echo "Patched source SHA-256 mismatch: $ACTUAL_SOURCE_SHA256" >&2
+    exit 1
+fi
+printf 'proved patched source SHA-256: %s\n' "$ACTUAL_SOURCE_SHA256"
+
+(
+    cd "$BASELINE"
+    "$PYTHON" setup.py build_ext --inplace --force
+)
+(
+    cd "$CANDIDATE"
+    "$PYTHON" setup.py build_ext --inplace --force
+)
+
+mkdir -p "$(dirname "$OUTPUT")"
+cd "$ROOT"
+"$PYTHON" -m tests.performance.experiments.exact_batch_storage_matrix \
+    --baseline-root "$BASELINE" \
+    --candidate-root "$CANDIDATE" \
+    --profile smoke \
+    --blocks 20 \
+    --output "$OUTPUT"

--- a/tests/applications/shared/test_lease_state_publication.py
+++ b/tests/applications/shared/test_lease_state_publication.py
@@ -1,0 +1,183 @@
+"""Publication, cache, and delta-staging contracts for the lease kernel."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
+
+import pytest
+
+from treemendous.applications._shared.clock import LogicalClock
+from treemendous.applications._shared.leasing import (
+    InvalidLeaseError,
+    Lease,
+    LeasePool,
+    LeaseState,
+    LeaseUnavailableError,
+)
+from treemendous.applications.leasing._common import NumericLease, PoolGroup
+from treemendous.domain import Span
+
+
+def _cache_state(pool: LeasePool) -> tuple[object, ...]:
+    return (
+        pool._leases,
+        pool._free,
+        pool._lease_projection_cache,
+        pool._available_projection_cache,
+        pool._state_counts_cache,
+        pool._next_fencing_token,
+    )
+
+
+def test_snapshot_projections_are_lazy_reused_and_point_in_time() -> None:
+    clock = LogicalClock()
+    pool = LeasePool((0, 8), clock=clock)
+    first_lease = pool.acquire("first", ttl=10, size=2)
+    assert pool._lease_projection_cache is None
+    assert pool._available_projection_cache is None
+    assert pool._state_counts_cache is None
+
+    first = pool.snapshot()
+    assert getattr(pool, "_lease_projection_cache") is first.leases
+    assert getattr(pool, "_available_projection_cache") is first.available_spans
+    counts = getattr(pool, "_state_counts_cache")
+    second = pool.snapshot()
+
+    assert second is not first
+    assert second.leases is first.leases
+    assert second.available_spans is first.available_spans
+    assert getattr(pool, "_state_counts_cache") is counts
+    assert second.diagnostics == first.diagnostics
+
+    renewed = pool.renew(first_lease, ttl=12)
+    assert getattr(pool, "_lease_projection_cache") is None
+    assert getattr(pool, "_state_counts_cache") is None
+    assert getattr(pool, "_available_projection_cache") is first.available_spans
+    after_renew = pool.snapshot()
+    assert after_renew.available_spans is first.available_spans
+    assert after_renew.leases != first.leases
+
+    pool.release(renewed)
+    after_release = pool.snapshot()
+    assert after_release.available_spans != first.available_spans
+    assert first.leases == (first_lease,)
+    assert first.available_spans == (Span(2, 8),)
+    assert first.diagnostics.active_leases == 1
+
+
+def test_failed_mutation_retains_published_state_and_all_projection_caches(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool = LeasePool((0, 2), clock=LogicalClock())
+    pool.acquire("owner", ttl=10)
+    pool.snapshot()
+    before = _cache_state(pool)
+
+    with pytest.raises(LeaseUnavailableError):
+        pool.acquire("blocked", ttl=10, exact_span=(0, 1))
+    assert _cache_state(pool) == before
+    assert all(
+        current is previous
+        for current, previous in zip(_cache_state(pool)[:5], before[:5], strict=True)
+    )
+
+    def fail_selection(*args: object, **kwargs: object) -> Span:
+        del args, kwargs
+        raise RuntimeError("injected selection failure")
+
+    monkeypatch.setattr(pool, "_select_span", fail_selection)
+    with pytest.raises(RuntimeError, match="injected"):
+        pool.acquire("next", ttl=10)
+    after = _cache_state(pool)
+    assert all(
+        current is previous
+        for current, previous in zip(after[:5], before[:5], strict=True)
+    )
+    assert after[5] == before[5]
+
+
+def test_rejected_free_delta_candidate_is_not_retained(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    pool = LeasePool((0, 20), clock=LogicalClock())
+    pool.acquire("owner", ttl=100)
+    replays = 0
+    original = pool._build_free
+
+    def observed_rebuild(leases: dict[int, Lease]) -> object:
+        nonlocal replays
+        replays += len(leases)
+        return original(leases)
+
+    monkeypatch.setattr(pool, "_build_free", observed_rebuild)
+    acquired = pool.acquire("new", ttl=100)
+    pool.release(acquired)
+
+    assert replays > 0
+    assert not hasattr(pool, "_clone_free")
+
+
+def test_fence_lookup_uses_no_public_snapshot_or_projection_scan_and_expires(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    clock = LogicalClock()
+    group = PoolGroup({"scope": (Span(0, 4),)}, clock=clock)
+    handle = group.acquire("scope", "owner", ttl=2)
+    pool = group.pool("scope")
+
+    def forbidden(*args: object, **kwargs: object) -> object:
+        del args, kwargs
+        raise AssertionError("public projection path was used")
+
+    monkeypatch.setattr(pool, "snapshot", forbidden)
+    monkeypatch.setattr(pool, "_lease_projection", forbidden)
+    assert group.validate_fence("key", handle)
+
+    clock.advance(2)
+    assert group.validate_fence("key", handle)
+    assert pool._leases[handle.token].state is LeaseState.EXPIRED
+    assert pool._free.intervals()[0].span == Span(0, 4)
+
+    unknown = NumericLease("scope", replace(handle.lease, fencing_token=99))
+    with pytest.raises(InvalidLeaseError, match="not issued"):
+        group.validate_fence("other", unknown)
+
+
+def test_expiration_boundary_and_checkpoint_restore_keep_indexes_consistent() -> None:
+    clock = LogicalClock(5)
+    pool = LeasePool((0, 4), clock=clock)
+    first = pool.acquire("first", ttl=2)
+    second = pool.acquire("second", ttl=3)
+    clock.advance(1)
+    assert pool.expire() == ()
+    clock.advance(1)
+    assert pool.expire() == (replace(first, state=LeaseState.EXPIRED),)
+    assert pool.snapshot().leases[1] == second
+
+    restored = LeasePool.from_checkpoint(pool.checkpoint(), clock=clock)
+    assert restored.snapshot().leases[0].state is LeaseState.EXPIRED
+
+
+def test_concurrent_snapshots_are_complete_and_share_only_immutable_projections() -> (
+    None
+):
+    pool = LeasePool((0, 128), clock=LogicalClock())
+    for index in range(64):
+        pool.acquire(f"owner-{index}", ttl=100)
+
+    def reader() -> tuple[object, object, int, int]:
+        snapshot = pool.snapshot()
+        return (
+            snapshot.leases,
+            snapshot.available_spans,
+            len(snapshot.leases),
+            snapshot.diagnostics.active_leases,
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as executor:
+        observed = tuple(executor.map(lambda _: reader(), range(128)))
+
+    assert {item[2:] for item in observed} == {(64, 64)}
+    assert len({id(item[0]) for item in observed}) == 1
+    assert len({id(item[1]) for item in observed}) == 1

--- a/tests/docs/test_readme.py
+++ b/tests/docs/test_readme.py
@@ -51,8 +51,32 @@ RUNNABLE_EXAMPLES = (
         "free=10000-10001,10003-10005,10006-10008 changed=2,1",
     ),
     (
+        ROOT / "examples/patterns/atomic_memory_map_updates.py",
+        "mapped=-4096:-2048,0:4096 changed=2048,4096,1024,1024",
+    ),
+    (
+        ROOT / "examples/patterns/atomic_partition_availability_updates.py",
+        "available=0:2,8:10,12:16 changed=2,4,2",
+    ),
+    (
+        ROOT / "examples/patterns/genomic_mask_batch_updates.py",
+        "masks=100:180 changed=40,40,20,20",
+    ),
+    (
         ROOT / "examples/patterns/spatiotemporal_geofences.py",
         "matches=alpha,beta handles=1,2,3 process_local=True",
+    ),
+    (
+        ROOT / "examples/patterns/warehouse_space_time_reservations.py",
+        "conflicts=forklift-a,forklift-b handles=1,2,3 remaining=1,3",
+    ),
+    (
+        ROOT / "examples/patterns/video_region_timeline_overlap.py",
+        "matches=title,title-copy order=1,2 touching=later remaining=2,3",
+    ),
+    (
+        ROOT / "examples/patterns/robot_volume_time_conflicts.py",
+        "conflicts=arm-a,arm-b handles=1,2,3 moved=2 remaining=2,3",
     ),
 )
 

--- a/tests/performance/experiments/__init__.py
+++ b/tests/performance/experiments/__init__.py
@@ -1,0 +1,1 @@
+"""Bounded, diagnostic performance experiments outside stable package code."""

--- a/tests/performance/experiments/application_backend_matrix.py
+++ b/tests/performance/experiments/application_backend_matrix.py
@@ -1,0 +1,1231 @@
+#!/usr/bin/env python3
+"""Concrete-application backend qualification experiment.
+
+The experiment is intentionally outside :mod:`treemendous`.  It temporarily
+replaces only the private RangeSet factories owned by the application kernels;
+public constructors and stable runtime behavior are never changed.  Every
+replacement delegates to one semantically probed :class:`BackendRegistry`.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import enum
+import hashlib
+import inspect
+import json
+import math
+import os
+import platform
+import random
+import statistics
+import subprocess
+import sysconfig
+import time
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any, TypeVar
+from uuid import UUID
+
+from treemendous.applications._shared import allocation, claiming, leasing
+from treemendous.applications._shared.allocation import ContiguousAllocator, FitPolicy
+from treemendous.applications._shared.claiming import ClaimLedger
+from treemendous.applications._shared.clock import LogicalClock
+from treemendous.applications.allocation.disk_blocks import DiskBlockAllocator
+from treemendous.applications.leasing._common import PoolGroup
+from treemendous.applications.partitioning._runtime import PartitionRuntime
+from treemendous.backends.registry import BackendRegistry
+from treemendous.backends.types import (
+    Available,
+    BackendSpec,
+    Capability,
+    Invalid,
+    Maturity,
+    Unavailable,
+)
+from treemendous.domain import Span
+from treemendous.rangeset import RangeSet
+
+SCHEMA = "treemendous-application-backend-matrix-v1"
+BASELINE_BACKEND = "py_boundary"
+ENGINE_NAMES = (
+    "contiguous_allocator",
+    "disk_block_allocator",
+    "pool_group",
+    "claim_ledger",
+    "partition_runtime",
+)
+MINIMUM_BLOCKS = 20
+BOOTSTRAP_RESAMPLES = 2_000
+BOOTSTRAP_SEED = 591_337
+PRIMARY_UPPER_95_LIMIT = 0.90
+CELL_UPPER_95_LIMIT = 1.10
+CURRENT_DEFAULT_UPPER_95_LIMIT = 1.10
+BUILD_FLAG_NAMES = (
+    "BOOST_ROOT",
+    "TREE_MENDOUS_DISABLE_OPTIMIZATIONS",
+    "TREE_MENDOUS_GLIBCXX_DEBUG",
+    "TREE_MENDOUS_LOCAL_NATIVE",
+    "TREE_MENDOUS_SANITIZERS",
+    "TREE_MENDOUS_WITH_ICL",
+)
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+_SOURCE_PATHS = (
+    "tests/performance/experiments/application_backend_matrix.py",
+    "treemendous/backends/registry.py",
+    "treemendous/backends/selection.py",
+    "treemendous/applications/_shared/allocation.py",
+    "treemendous/applications/_shared/leasing.py",
+    "treemendous/applications/_shared/claiming.py",
+    "treemendous/applications/leasing/_common.py",
+    "treemendous/applications/partitioning/_runtime.py",
+    "treemendous/applications/allocation/disk_blocks.py",
+)
+T = TypeVar("T")
+
+
+class QualificationError(ValueError):
+    """A requested backend failed the experiment's fixed eligibility rules."""
+
+
+@dataclasses.dataclass
+class _FactoryTracker:
+    backend: str
+    expected_type: type[Any]
+    objects: list[Any] = dataclasses.field(default_factory=list)
+
+    def record(self, ranges: RangeSet) -> RangeSet:
+        implementation = ranges._adapter.implementation
+        if type(implementation) is not self.expected_type:
+            raise AssertionError(
+                f"factory for {self.backend} constructed {type(implementation)!r}"
+            )
+        self.objects.append(implementation)
+        return ranges
+
+    def evidence(self) -> dict[str, Any]:
+        if not self.objects:
+            raise AssertionError("application trace did not call a patched factory")
+        ids = [id(item) for item in self.objects]
+        if len(ids) != len(set(ids)):
+            raise AssertionError("factory implementation identities were reused")
+        return {
+            "calls": len(ids),
+            "implementation_ids": ids,
+            "implementation_module": self.expected_type.__module__,
+            "implementation_type": self.expected_type.__qualname__,
+        }
+
+
+class _PatchedFactoryContext:
+    """Temporarily route private application factories through one registry spec."""
+
+    def __init__(self, registry: BackendRegistry, spec: BackendSpec) -> None:
+        self._registry = registry
+        self._spec = spec
+        self._counter = 0
+        self._tracker = _FactoryTracker(spec.id, spec.loader())
+        self._originals: tuple[Any, ...] | None = None
+
+    def _new_ranges(self, domain: Any) -> RangeSet:
+        return self._tracker.record(
+            self._registry.create(
+                domain,
+                backend=self._spec.id,
+                initially_available=True,
+            )
+        )
+
+    def _new_allocation_ranges(self, domain: Any) -> RangeSet:
+        return self._new_ranges(domain)
+
+    def _new_claim_ranges(self, domain: Any, claims: tuple[Any, ...] = ()) -> RangeSet:
+        ranges = self._new_ranges(domain)
+        for claim in claims:
+            if claim.state in {
+                claiming.ClaimState.ACTIVE,
+                claiming.ClaimState.COMPLETED,
+            }:
+                mutation = ranges.discard(claim.span, require_covered=True)
+                if not mutation.fully_covered:
+                    raise claiming.ClaimInvariantError(
+                        "consuming claims overlap or leave the domain"
+                    )
+        return ranges
+
+    def _next_hex(self, _length: int | None = 16) -> str:
+        self._counter += 1
+        return f"experiment-{self._counter:08d}"
+
+    def _next_uuid(self) -> UUID:
+        self._counter += 1
+        return UUID(int=self._counter)
+
+    def __enter__(self) -> _FactoryTracker:
+        context = self
+
+        def new_lease_ranges(instance: Any) -> RangeSet:
+            return context._new_ranges(instance._domain)
+
+        self._originals = (
+            allocation._new_range_set,
+            leasing.LeasePool._new_range_set,
+            claiming._new_free,
+            allocation.uuid4,
+            leasing.secrets.token_hex,
+            claiming.secrets.token_hex,
+        )
+        setattr(allocation, "_new_range_set", self._new_allocation_ranges)
+        setattr(leasing.LeasePool, "_new_range_set", new_lease_ranges)
+        setattr(claiming, "_new_free", self._new_claim_ranges)
+        setattr(allocation, "uuid4", self._next_uuid)
+        setattr(leasing.secrets, "token_hex", self._next_hex)
+        setattr(claiming.secrets, "token_hex", self._next_hex)
+        return self._tracker
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: Any,
+    ) -> None:
+        del exc_type, exc_value, traceback
+        originals = self._originals
+        if originals is None:
+            raise RuntimeError("patched factory context was not entered")
+        (
+            old_allocation,
+            old_lease,
+            old_claim,
+            old_uuid,
+            old_lease_hex,
+            old_claim_hex,
+        ) = originals
+        setattr(allocation, "_new_range_set", old_allocation)
+        setattr(leasing.LeasePool, "_new_range_set", old_lease)
+        setattr(claiming, "_new_free", old_claim)
+        setattr(allocation, "uuid4", old_uuid)
+        setattr(leasing.secrets, "token_hex", old_lease_hex)
+        setattr(claiming.secrets, "token_hex", old_claim_hex)
+        self._originals = None
+
+
+def _patched_factories(
+    registry: BackendRegistry, spec: BackendSpec
+) -> _PatchedFactoryContext:
+    """Return a scoped private-factory patch for one qualified backend."""
+    return _PatchedFactoryContext(registry, spec)
+
+
+def _rejection_reasons(spec: BackendSpec, state: Any) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if isinstance(state, Unavailable):
+        reasons.append(f"unavailable: {state.reason}")
+    elif isinstance(state, Invalid):
+        reasons.append(f"invalid: {state.error}")
+    elif not isinstance(state, Available):
+        reasons.append("unavailable: missing semantic probe")
+    if spec.maturity is not Maturity.STABLE:
+        reasons.append("experimental")
+    if spec.coordinate_bits != 64:
+        reasons.append("coordinate width is not signed 64-bit")
+    if not spec.deterministic:
+        reasons.append("nondeterministic")
+    if Capability.CORE not in spec.capabilities:
+        reasons.append("missing CORE capability declaration")
+    if (
+        isinstance(state, Available)
+        and Capability.CORE not in state.validated_capabilities
+    ):
+        reasons.append("CORE capability was not semantically validated")
+    return tuple(reasons)
+
+
+def _qualify_backend(registry: BackendRegistry, backend: str) -> BackendSpec:
+    spec = next((item for item in registry.specs if item.id == backend), None)
+    if spec is None:
+        raise QualificationError(f"unknown backend: {backend}")
+    reasons = _rejection_reasons(spec, registry.states[backend])
+    if reasons:
+        raise QualificationError(f"backend {backend} rejected: {'; '.join(reasons)}")
+    # Construction must traverse the canonical registry resolution path.  The
+    # temporary object is deliberately discarded before application tracing.
+    registry.create((-(2**63), -(2**63) + 1), backend=backend)
+    return spec
+
+
+def _eligible_specs(registry: BackendRegistry) -> tuple[BackendSpec, ...]:
+    result = []
+    for spec in registry.specs:
+        try:
+            result.append(_qualify_backend(registry, spec.id))
+        except QualificationError:
+            pass
+    if not any(spec.id == BASELINE_BACKEND for spec in result):
+        raise RuntimeError("qualified py_boundary baseline is unavailable")
+    return tuple(result)
+
+
+def _freeze(value: Any) -> Any:
+    """Convert application evidence to exact, canonical JSON values."""
+    if value is None or type(value) in (bool, int, str):
+        return value
+    if type(value) is float:
+        if not math.isfinite(value):
+            raise ValueError("application evidence contains a non-finite float")
+        return value
+    if isinstance(value, enum.Enum):
+        return {
+            "enum": f"{type(value).__module__}.{type(value).__qualname__}",
+            "value": _freeze(value.value),
+        }
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return {
+            "type": f"{type(value).__module__}.{type(value).__qualname__}",
+            "fields": {
+                field.name: _freeze(getattr(value, field.name))
+                for field in dataclasses.fields(value)
+            },
+        }
+    if isinstance(value, dict):
+        return {
+            str(key): _freeze(item)
+            for key, item in sorted(value.items(), key=lambda row: str(row[0]))
+        }
+    if isinstance(value, (tuple, list)):
+        return [_freeze(item) for item in value]
+    raise TypeError(f"cannot freeze application evidence of type {type(value)!r}")
+
+
+def _observed_call(call: Callable[[], Any]) -> dict[str, Any]:
+    try:
+        return {"result": _freeze(call())}
+    except Exception as error:  # noqa: BLE001 - exceptions are experiment evidence
+        return {
+            "exception": {
+                "module": type(error).__module__,
+                "type": type(error).__qualname__,
+                "message": str(error),
+            }
+        }
+
+
+def _contiguous_action() -> Callable[[], Any]:
+    allocator = ContiguousAllocator((-64, 256), reserved=((-64, -56), (120, 128)))
+    seed_left = allocator.allocate(13, owner="seed-left", alignment=4)
+    seed_right = allocator.allocate(9, owner="seed-right", alignment=8)
+    allocator.free(seed_left, owner="seed-left")
+
+    def action() -> Any:
+        calls = []
+        calls.append(
+            _observed_call(
+                lambda: allocator.allocate(
+                    11,
+                    owner="alpha",
+                    alignment=4,
+                    policy=FitPolicy.BEST,
+                    idempotency_key="a",
+                )
+            )
+        )
+        calls.append(
+            _observed_call(
+                lambda: allocator.reserve(
+                    80, 7, owner="beta", alignment=8, idempotency_key="b"
+                )
+            )
+        )
+        checkpoint = allocator.checkpoint()
+        temporary = allocator.allocate(5, owner="temporary", policy=FitPolicy.WORST)
+        allocator.free(temporary, owner="temporary")
+        allocator.reserve_hole((144, 151))
+        allocator.restore(checkpoint)
+        calls.append(_observed_call(lambda: allocator.reserve(80, 2, owner="conflict")))
+        replay = allocator.allocate(3, owner="replay", alignment=2)
+        calls.append({"result": _freeze(replay)})
+        return {
+            "calls": calls,
+            "checkpoint": _freeze(checkpoint),
+            "diagnostics": _freeze(allocator.diagnostics()),
+            "snapshot": _freeze(allocator.snapshot()),
+            "final_geometry": _freeze(allocator.snapshot().free_ranges),
+            "seed_right": _freeze(seed_right),
+        }
+
+    return action
+
+
+def _disk_action() -> Callable[[], Any]:
+    disk = DiskBlockAllocator(256, metadata_blocks=4, fit_policy=FitPolicy.BEST)
+    old = disk.allocate_extent("seed", 9)
+    disk.allocate_extent("resident", 13)
+    disk.free_extent(old, file_id="seed")
+
+    def action() -> Any:
+        calls = [
+            _observed_call(lambda: disk.allocate_extent("alpha", 17)),
+            _observed_call(
+                lambda: disk.allocate_extent("beta", 7, policy=FitPolicy.WORST)
+            ),
+        ]
+        checkpoint = disk.checkpoint()
+        temporary = disk.allocate_extent("temporary", 5)
+        disk.free_extent(temporary, file_id="temporary")
+        disk.restore(checkpoint)
+        calls.append(_observed_call(lambda: disk.allocate_extent("oversized", 10_000)))
+        calls.append(_observed_call(lambda: disk.allocate_extent("replay", 3)))
+        snapshot = disk.snapshot()
+        return {
+            "calls": calls,
+            "checkpoint": _freeze(checkpoint),
+            "diagnostics": _freeze(snapshot.diagnostics),
+            "snapshot": _freeze(snapshot),
+            "final_geometry": _freeze(snapshot.free_extents),
+        }
+
+    return action
+
+
+def _pool_group_action() -> Callable[[], Any]:
+    clock = LogicalClock(100)
+    group = PoolGroup(
+        {"alpha": (Span(-32, 64),), "beta": (Span(100, 180),)}, clock=clock
+    )
+
+    def action() -> Any:
+        first = group.acquire("alpha", "worker-a", ttl=50, size=7, request_id="a")
+        second = group.acquire("beta", "worker-b", ttl=40, size=5, request_id="b")
+        renewed = group.renew(first, ttl=80)
+        released = group.release(second)
+        checkpoint = group.checkpoint()
+        restored = PoolGroup.restore(checkpoint, clock=clock)
+        replay = restored.acquire("alpha", "worker-c", ttl=20, size=3, request_id="c")
+        failure = _observed_call(lambda: restored.release(renewed))
+        return {
+            "results": _freeze((first, second, renewed, released, replay)),
+            "exception": failure,
+            "snapshot": _freeze(group.snapshot()),
+            "diagnostics": _freeze(group.diagnostics()),
+            "checkpoint": _freeze(checkpoint),
+            "restored_snapshot": _freeze(restored.snapshot()),
+            "restored_checkpoint": _freeze(restored.checkpoint()),
+            "final_geometry": _freeze(
+                tuple(
+                    (scope, pool.snapshot().available_spans)
+                    for scope, pool in sorted(restored.pools.items())
+                )
+            ),
+        }
+
+    return action
+
+
+def _claim_ledger_action() -> Callable[[], Any]:
+    clock = LogicalClock(100)
+    ledger = ClaimLedger((-16, 128), clock=clock)
+
+    def action() -> Any:
+        first = ledger.claim_next("worker-a", 11, request_id="a", ttl=50)
+        second = ledger.claim_next("worker-b", 7, request_id="b")
+        renewed = ledger.renew(first, ttl=70)
+        abandoned = ledger.abandon(second)
+        checkpoint = ledger.checkpoint()
+        restored = ClaimLedger.from_checkpoint(checkpoint, clock=clock)
+        replay = restored.claim_next("worker-c", 5, request_id="c")
+        failure = _observed_call(lambda: restored.complete(first))
+        completed = restored.complete(replay, result={"rows": 5})
+        snapshot = restored.snapshot()
+        return {
+            "results": _freeze((first, second, renewed, abandoned, replay, completed)),
+            "exception": failure,
+            "snapshot": _freeze(snapshot),
+            "diagnostics": _freeze(snapshot.diagnostics),
+            "checkpoint": _freeze(checkpoint),
+            "restored_checkpoint": _freeze(restored.checkpoint()),
+            "events": _freeze(restored.events()),
+            "violations": _freeze(restored.invariant_violations()),
+            "final_geometry": _freeze(snapshot.available),
+        }
+
+    return action
+
+
+def _partition_runtime_action() -> Callable[[], Any]:
+    clock = LogicalClock(100)
+    runtime = PartitionRuntime(96, clock=clock)
+
+    def action() -> Any:
+        first = runtime.claim("worker-a", 13, request_id="a")
+        completed = runtime.complete(first, "indexed", {"rows": 13})
+        second = runtime.claim("worker-b", 9, request_id="b")
+        abandoned = runtime.abandon(second)
+        checkpoint = runtime.checkpoint()
+        restored = PartitionRuntime.from_checkpoint(checkpoint, clock=clock)
+        replay = restored.claim("worker-c", 7, request_id="c")
+        replay_completed = restored.complete(replay, "replayed", {"rows": 7})
+        audit, restored_checkpoint = restored.audit_snapshot(restored.ledger.snapshot)
+        failure = _observed_call(lambda: restored.complete(first, "stale"))
+        return {
+            "results": _freeze(
+                (first, completed, second, abandoned, replay, replay_completed)
+            ),
+            "exception": failure,
+            "snapshot": _freeze(audit),
+            "diagnostics": _freeze(audit.diagnostics),
+            "checkpoint": _freeze(checkpoint),
+            "restored_checkpoint": _freeze(restored_checkpoint),
+            "events": _freeze(restored.log.snapshot()),
+            "final_geometry": _freeze(audit.available),
+        }
+
+    return action
+
+
+_ENGINE_FACTORIES: dict[str, Callable[[], Callable[[], Any]]] = {
+    "contiguous_allocator": _contiguous_action,
+    "disk_block_allocator": _disk_action,
+    "pool_group": _pool_group_action,
+    "claim_ledger": _claim_ledger_action,
+    "partition_runtime": _partition_runtime_action,
+}
+
+
+def _execute_once(
+    registry: BackendRegistry, spec: BackendSpec, engine: str
+) -> tuple[int, Any, dict[str, Any]]:
+    with _patched_factories(registry, spec) as tracker:
+        action = _ENGINE_FACTORIES[engine]()  # setup is outside the timer
+        started = time.perf_counter_ns()
+        semantic = action()
+        elapsed = time.perf_counter_ns() - started
+        factory_evidence = tracker.evidence()
+    return elapsed, semantic, factory_evidence
+
+
+def _sha(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value, sort_keys=True, separators=(",", ":"), allow_nan=False
+        ).encode()
+    ).hexdigest()
+
+
+def _bootstrap(values: Sequence[float], seed: int) -> dict[str, float]:
+    if not values:
+        raise ValueError("bootstrap values must not be empty")
+    rng = random.Random(seed)
+    try:
+        medians = sorted(
+            statistics.median(rng.choices(values, k=len(values)))
+            for _ in range(BOOTSTRAP_RESAMPLES)
+        )
+        median = float(statistics.median(values))
+        lower = float(medians[int(0.025 * len(medians))])
+        upper = float(medians[int(0.975 * len(medians))])
+    except (IndexError, TypeError, ValueError, statistics.StatisticsError) as exc:
+        raise ValueError("bootstrap values are invalid") from exc
+    return {
+        "median": median,
+        "median_95_low": lower,
+        "median_95_high": upper,
+    }
+
+
+def _correctness_rows(
+    registry: BackendRegistry,
+    specs: Sequence[BackendSpec],
+    engines: Sequence[str],
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    baseline: dict[str, Any] = {}
+    baseline_factories: dict[str, Any] = {}
+    baseline_spec = next(spec for spec in specs if spec.id == BASELINE_BACKEND)
+    for engine in engines:
+        _, semantic, factories = _execute_once(registry, baseline_spec, engine)
+        baseline[engine] = semantic
+        baseline_factories[engine] = factories
+
+    rows: list[dict[str, Any]] = []
+    for spec in specs:
+        for engine in engines:
+            if spec.id == BASELINE_BACKEND:
+                semantic = baseline[engine]
+                factories = baseline_factories[engine]
+            else:
+                _, semantic, factories = _execute_once(registry, spec, engine)
+            if semantic != baseline[engine]:
+                raise AssertionError(
+                    f"{spec.id}/{engine} differs from exact py_boundary evidence"
+                )
+            rows.append(
+                {
+                    "backend": spec.id,
+                    "engine": engine,
+                    "semantic": semantic,
+                    "semantic_sha256": _sha(semantic),
+                    "baseline_sha256": _sha(baseline[engine]),
+                    "factory": factories,
+                }
+            )
+    return rows, baseline
+
+
+def _measure_row(
+    registry: BackendRegistry,
+    baseline: BackendSpec,
+    candidate: BackendSpec,
+    engine: str,
+    blocks: int,
+    expected: Any,
+    *,
+    phase: str,
+) -> dict[str, Any]:
+    raw_blocks = []
+    ratios = []
+    for block in range(blocks):
+        labels = (
+            ("candidate", "baseline") if block % 2 == 0 else ("baseline", "candidate")
+        )
+        order = (candidate, baseline) if block % 2 == 0 else (baseline, candidate)
+        elapsed: dict[str, int] = {}
+        for label, spec in zip(labels, order, strict=True):
+            duration, semantic, _ = _execute_once(registry, spec, engine)
+            # Correctness is checked on the exact instance after its timed call.
+            if semantic != expected:
+                raise AssertionError(
+                    f"timed {spec.id}/{engine} result differs from baseline"
+                )
+            elapsed[label] = duration
+        ratio = elapsed["candidate"] / max(1, elapsed["baseline"])
+        ratios.append(ratio)
+        raw_blocks.append(
+            {
+                "block": block,
+                "order": list(labels),
+                "candidate_ns": elapsed["candidate"],
+                "baseline_ns": elapsed["baseline"],
+                "ratio": ratio,
+            }
+        )
+    seed = BOOTSTRAP_SEED + sum(ord(char) for char in candidate.id + engine + phase)
+    return {
+        "phase": phase,
+        "backend": candidate.id,
+        "engine": engine,
+        "blocks": raw_blocks,
+        "ratios": ratios,
+        "ratio": _bootstrap(ratios, seed),
+        "validated_blocks": blocks,
+        "semantic_sha256": _sha(expected),
+    }
+
+
+def _gate(
+    specs: Sequence[BackendSpec],
+    initial: Sequence[dict[str, Any]],
+    confirmation: Sequence[dict[str, Any]],
+    engines: Sequence[str],
+) -> dict[str, Any]:
+    by_backend = {
+        spec.id: [row for row in initial if row["backend"] == spec.id] for spec in specs
+    }
+    initial_candidates = []
+    for backend, rows in by_backend.items():
+        if backend == BASELINE_BACKEND:
+            continue
+        if (
+            len(rows) == len(engines)
+            and min(row["ratio"]["median_95_high"] for row in rows)
+            <= PRIMARY_UPPER_95_LIMIT
+            and max(row["ratio"]["median_95_high"] for row in rows)
+            <= CELL_UPPER_95_LIMIT
+        ):
+            initial_candidates.append(backend)
+    confirmed = []
+    for backend in initial_candidates:
+        rows = [row for row in confirmation if row["backend"] == backend]
+        if (
+            len(rows) == len(engines)
+            and min(row["ratio"]["median_95_high"] for row in rows)
+            <= PRIMARY_UPPER_95_LIMIT
+            and max(row["ratio"]["median_95_high"] for row in rows)
+            <= CELL_UPPER_95_LIMIT
+        ):
+            confirmed.append(backend)
+    default_rows = by_backend[BASELINE_BACKEND]
+    default_pass = (
+        len(default_rows) == len(engines)
+        and max(row["ratio"]["median_95_high"] for row in default_rows)
+        <= CURRENT_DEFAULT_UPPER_95_LIMIT
+    )
+    qualified = confirmed if default_pass else []
+    return {
+        "decision": "QUALIFIED" if qualified else "REJECTED",
+        "primary_upper_95_limit": PRIMARY_UPPER_95_LIMIT,
+        "cell_upper_95_limit": CELL_UPPER_95_LIMIT,
+        "current_default_upper_95_limit": CURRENT_DEFAULT_UPPER_95_LIMIT,
+        "current_default_pass": default_pass,
+        "initial_candidates": initial_candidates,
+        "confirmed_backends": confirmed,
+        "qualified_backends": qualified,
+        "runtime_injection_retained": False,
+    }
+
+
+def _negative_case(
+    case: str, registry: BackendRegistry, backend: str
+) -> dict[str, Any]:
+    try:
+        _qualify_backend(registry, backend)
+    except Exception as error:  # noqa: BLE001 - fail-closed evidence
+        return {
+            "case": case,
+            "backend": backend,
+            "accepted": False,
+            "fallback_backend": None,
+            "exception_type": type(error).__qualname__,
+            "reason": str(error),
+        }
+    raise AssertionError(f"negative qualification case {case!r} was accepted")
+
+
+def _negative_evidence(registry: BackendRegistry) -> list[dict[str, Any]]:
+    specs = registry.specs
+    baseline = next(spec for spec in specs if spec.id == BASELINE_BACKEND)
+    unavailable = BackendRegistry(
+        specs,
+        {**registry.states, baseline.id: Unavailable("synthetic unavailable probe")},
+    )
+    invalid = BackendRegistry(
+        specs, {**registry.states, baseline.id: Invalid("synthetic invalid probe")}
+    )
+    experimental = next(
+        spec for spec in specs if spec.maturity is Maturity.EXPERIMENTAL
+    )
+    width = next(spec for spec in specs if spec.coordinate_bits != 64)
+    nondeterministic = next(spec for spec in specs if not spec.deterministic)
+    return [
+        _negative_case("unknown", registry, "does-not-exist"),
+        _negative_case("unavailable", unavailable, baseline.id),
+        _negative_case("invalid", invalid, baseline.id),
+        _negative_case("experimental", registry, experimental.id),
+        _negative_case("32-bit", registry, width.id),
+        _negative_case("nondeterministic", registry, nondeterministic.id),
+    ]
+
+
+def _methodology(blocks: int, engines: Sequence[str]) -> dict[str, Any]:
+    return {
+        "baseline_backend": BASELINE_BACKEND,
+        "engines": list(engines),
+        "minimum_blocks": MINIMUM_BLOCKS,
+        "blocks": blocks,
+        "balanced_order": "candidate/baseline alternates by block",
+        "setup_timing": "application construction and seed state excluded",
+        "correctness_timing": "same timed instance checked after timing",
+        "bootstrap_resamples": BOOTSTRAP_RESAMPLES,
+        "bootstrap_seed": BOOTSTRAP_SEED,
+        "primary_upper_95_limit": PRIMARY_UPPER_95_LIMIT,
+        "cell_upper_95_limit": CELL_UPPER_95_LIMIT,
+        "current_default_upper_95_limit": CURRENT_DEFAULT_UPPER_95_LIMIT,
+    }
+
+
+def _git_metadata() -> dict[str, Any]:
+    def git(*args: str) -> str:
+        return subprocess.run(
+            ["git", *args],
+            cwd=_REPOSITORY_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+
+    status = git("status", "--porcelain=v1", "--untracked-files=all")
+    changed = sorted(line[3:] for line in status.splitlines() if len(line) >= 4)
+    staged = sorted(
+        path for path in git("diff", "--cached", "--name-only").splitlines() if path
+    )
+    digest = hashlib.sha256()
+    digest.update(git("rev-parse", "HEAD").strip().encode())
+    for relative in changed:
+        path = _REPOSITORY_ROOT / relative
+        digest.update(relative.encode())
+        digest.update(b"\0")
+        if path.is_file():
+            digest.update(hashlib.sha256(path.read_bytes()).digest())
+    return {
+        "commit": git("rev-parse", "HEAD").strip(),
+        "head_tree": git("rev-parse", "HEAD^{tree}").strip(),
+        "clean_worktree": not bool(status),
+        "changed_paths": changed,
+        "staged_files": staged,
+        "source_state_sha256": digest.hexdigest(),
+    }
+
+
+def _file(path: Path) -> dict[str, str]:
+    resolved = path.resolve()
+    try:
+        shown = str(resolved.relative_to(_REPOSITORY_ROOT))
+    except ValueError:
+        shown = str(resolved)
+    return {"path": shown, "sha256": hashlib.sha256(resolved.read_bytes()).hexdigest()}
+
+
+def _backend_provenance(specs: Sequence[BackendSpec]) -> list[dict[str, Any]]:
+    rows = []
+    for spec in specs:
+        implementation = spec.loader()
+        path = Path(inspect.getfile(implementation))
+        rows.append(
+            {
+                "id": spec.id,
+                "module": implementation.__module__,
+                "type": implementation.__qualname__,
+                "runtime": spec.runtime.value,
+                "coordinate_bits": spec.coordinate_bits,
+                "deterministic": spec.deterministic,
+                "binary": _file(path),
+            }
+        )
+    return rows
+
+
+def _compiler_version() -> str:
+    compiler = os.environ.get("CXX", "c++")
+    try:
+        result = subprocess.run(
+            [compiler, "--version"], check=True, capture_output=True, text=True
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return "unavailable"
+    return result.stdout.splitlines()[0] if result.stdout else "unavailable"
+
+
+def _provenance(specs: Sequence[BackendSpec]) -> dict[str, Any]:
+    return {
+        "git": _git_metadata(),
+        "sources": [_file(_REPOSITORY_ROOT / relative) for relative in _SOURCE_PATHS],
+        "runtime": {
+            "python_version": platform.python_version(),
+            "python_implementation": platform.python_implementation(),
+            "python_compiler": platform.python_compiler(),
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "architecture": platform.architecture()[0],
+        },
+        "build": {
+            "command": os.environ.get(
+                "TREE_MENDOUS_BUILD_COMMAND", "uv sync --all-extras"
+            ),
+            "cxx": os.environ.get("CXX", "c++"),
+            "cxx_version": _compiler_version(),
+            "cc": str(sysconfig.get_config_var("CC") or "unknown"),
+            "cflags": str(sysconfig.get_config_var("CFLAGS") or "unknown"),
+            "flags": {name: os.environ.get(name, "") for name in BUILD_FLAG_NAMES},
+        },
+        "backends": _backend_provenance(specs),
+    }
+
+
+def run_matrix(
+    *,
+    blocks: int = MINIMUM_BLOCKS,
+    backend_ids: Sequence[str] | None = None,
+    engines: Sequence[str] = ENGINE_NAMES,
+) -> dict[str, Any]:
+    """Run the bounded correctness and paired qualification matrix."""
+    if type(blocks) is not int or blocks < MINIMUM_BLOCKS:
+        raise ValueError(f"blocks must be an integer >= {MINIMUM_BLOCKS}")
+    expected_engines = tuple(engine for engine in ENGINE_NAMES if engine in engines)
+    if not engines or tuple(engines) != expected_engines:
+        raise ValueError(
+            "engines must be an ordered unique nonempty subset of the fixed matrix"
+        )
+    registry = BackendRegistry.discover()
+    eligible = _eligible_specs(registry)
+    if backend_ids is not None:
+        requested = tuple(backend_ids)
+        if BASELINE_BACKEND not in requested:
+            requested = (BASELINE_BACKEND, *requested)
+        eligible = tuple(spec for spec in eligible if spec.id in requested)
+        missing = set(requested) - {spec.id for spec in eligible}
+        if missing:
+            raise QualificationError(
+                f"requested backends are not qualified: {sorted(missing)}"
+            )
+    correctness, baseline_semantics = _correctness_rows(registry, eligible, engines)
+    baseline = next(spec for spec in eligible if spec.id == BASELINE_BACKEND)
+    initial = [
+        _measure_row(
+            registry,
+            baseline,
+            spec,
+            engine,
+            blocks,
+            baseline_semantics[engine],
+            phase="initial",
+        )
+        for spec in eligible
+        for engine in engines
+    ]
+    preliminary = _gate(eligible, initial, (), engines)
+    confirmation = [
+        _measure_row(
+            registry,
+            baseline,
+            spec,
+            engine,
+            blocks,
+            baseline_semantics[engine],
+            phase="confirmation",
+        )
+        for spec in eligible
+        if spec.id in preliminary["initial_candidates"]
+        for engine in engines
+    ]
+    gate = _gate(eligible, initial, confirmation, engines)
+    return {
+        "schema": SCHEMA,
+        "methodology": _methodology(blocks, engines),
+        "eligible_backends": [spec.id for spec in eligible],
+        "negative_requests": _negative_evidence(registry),
+        "correctness": correctness,
+        "benchmarks": initial,
+        "confirmation": confirmation,
+        "gate": gate,
+        "provenance": _provenance(eligible),
+    }
+
+
+def _markdown(report: dict[str, Any], digest: str) -> str:
+    lines = [
+        "# Concrete application backend qualification experiment",
+        "",
+        f"Decision: **{report['gate']['decision']}**",
+        f"Runtime injection retained: **{report['gate']['runtime_injection_retained']}**",
+        f"JSON SHA-256: `{digest}`",
+        "",
+        "| phase | backend | engine | median ratio | upper 95% |",
+        "| --- | --- | --- | ---: | ---: |",
+    ]
+    for row in [*report["benchmarks"], *report["confirmation"]]:
+        lines.append(
+            f"| {row['phase']} | {row['backend']} | {row['engine']} | "
+            f"{row['ratio']['median']:.4f} | {row['ratio']['median_95_high']:.4f} |"
+        )
+    lines.extend(("", "## Negative requests", ""))
+    lines.extend(
+        f"- `{row['case']}` / `{row['backend']}`: {row['reason']}"
+        for row in report["negative_requests"]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_artifacts(report: dict[str, Any], output: Path) -> tuple[Path, Path, Path]:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (
+        json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    ).encode()
+    output.write_bytes(encoded)
+    digest = hashlib.sha256(encoded).hexdigest()
+    markdown = output.with_suffix(".md")
+    markdown.write_text(_markdown(report, digest))
+    checksum = Path(f"{output}.sha256")
+    checksum.write_text(f"{digest}  {output.name}\n")
+    return output, markdown, checksum
+
+
+def _duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate key: {key!r}")
+        result[key] = value
+    return result
+
+
+def _nonfinite(value: str) -> None:
+    raise ValueError(f"non-finite number: {value}")
+
+
+def _finite(value: str) -> float:
+    try:
+        result = float(value)
+    except (TypeError, ValueError, OverflowError) as exc:
+        raise ValueError(f"invalid number: {value}") from exc
+    if not math.isfinite(result):
+        raise ValueError(f"non-finite number: {value}")
+    return result
+
+
+def _exact(left: Any, right: Any) -> bool:
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, dict):
+        return left.keys() == right.keys() and all(
+            _exact(left[key], right[key]) for key in left
+        )
+    if isinstance(left, list):
+        return len(left) == len(right) and all(
+            _exact(a, b) for a, b in zip(left, right, strict=True)
+        )
+    return bool(left == right)
+
+
+def _verify_benchmark_row(row: Any, blocks: int) -> None:
+    keys = {
+        "phase",
+        "backend",
+        "engine",
+        "blocks",
+        "ratios",
+        "ratio",
+        "validated_blocks",
+        "semantic_sha256",
+    }
+    if type(row) is not dict or set(row) != keys:
+        raise ValueError("benchmark row schema mismatch")
+    if (
+        type(row["phase"]) is not str
+        or row["phase"] not in {"initial", "confirmation"}
+        or type(row["backend"]) is not str
+        or type(row["engine"]) is not str
+        or row["engine"] not in ENGINE_NAMES
+    ):
+        raise ValueError("benchmark row identity exact type mismatch")
+    if type(row["validated_blocks"]) is not int or row["validated_blocks"] != blocks:
+        raise ValueError("validated block count mismatch")
+    raw = row["blocks"]
+    if type(raw) is not list or len(raw) != blocks:
+        raise ValueError("raw block count mismatch")
+    ratios = []
+    for index, block in enumerate(raw):
+        if type(block) is not dict or set(block) != {
+            "block",
+            "order",
+            "candidate_ns",
+            "baseline_ns",
+            "ratio",
+        }:
+            raise ValueError("raw block schema mismatch")
+        expected_order = (
+            ["candidate", "baseline"] if index % 2 == 0 else ["baseline", "candidate"]
+        )
+        if block["block"] != index or block["order"] != expected_order:
+            raise ValueError("balanced block ordering mismatch")
+        if (
+            type(block["candidate_ns"]) is not int
+            or type(block["baseline_ns"]) is not int
+            or min(block["candidate_ns"], block["baseline_ns"]) <= 0
+        ):
+            raise ValueError("block duration exact type/value mismatch")
+        expected = block["candidate_ns"] / block["baseline_ns"]
+        if type(block["ratio"]) is not float or block["ratio"] != expected:
+            raise ValueError("raw block ratio mismatch")
+        ratios.append(expected)
+    if not _exact(row["ratios"], ratios):
+        raise ValueError("derived ratio samples mismatch")
+    seed = BOOTSTRAP_SEED + sum(
+        ord(char) for char in row["backend"] + row["engine"] + row["phase"]
+    )
+    if not _exact(row["ratio"], _bootstrap(ratios, seed)):
+        raise ValueError("derived ratio interval mismatch")
+
+
+def verify_artifacts(output: Path) -> dict[str, Any]:
+    """Strictly parse and recompute the canonical artifact triplet."""
+    encoded = output.read_bytes()
+    digest = hashlib.sha256(encoded).hexdigest()
+    if Path(f"{output}.sha256").read_text() != f"{digest}  {output.name}\n":
+        raise ValueError("checksum mismatch")
+    try:
+        report = json.loads(
+            encoded,
+            object_pairs_hook=_duplicates,
+            parse_constant=_nonfinite,
+            parse_float=_finite,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError, TypeError) as exc:
+        raise ValueError("application-backend JSON is invalid") from exc
+    top = {
+        "schema",
+        "methodology",
+        "eligible_backends",
+        "negative_requests",
+        "correctness",
+        "benchmarks",
+        "confirmation",
+        "gate",
+        "provenance",
+    }
+    if type(report) is not dict or set(report) != top or report["schema"] != SCHEMA:
+        raise ValueError("report schema mismatch")
+    methodology = report["methodology"]
+    if type(methodology) is not dict:
+        raise ValueError("methodology schema mismatch")
+    blocks = methodology.get("blocks")
+    engines = methodology.get("engines")
+    if type(blocks) is not int or blocks < MINIMUM_BLOCKS or type(engines) is not list:
+        raise ValueError("methodology exact type/value mismatch")
+    expected_engines = [engine for engine in ENGINE_NAMES if engine in engines]
+    if engines != expected_engines:
+        raise ValueError("methodology engine order/uniqueness mismatch")
+    if not _exact(methodology, _methodology(blocks, engines)):
+        raise ValueError("fixed methodology mismatch")
+    eligible_ids = report["eligible_backends"]
+    if (
+        type(eligible_ids) is not list
+        or not eligible_ids
+        or any(type(item) is not str for item in eligible_ids)
+    ):
+        raise ValueError("eligible backend schema mismatch")
+    registry = BackendRegistry.discover()
+    if len(set(eligible_ids)) != len(eligible_ids):
+        raise ValueError("eligible backend order/uniqueness mismatch")
+    available_order = [spec.id for spec in _eligible_specs(registry)]
+    expected_eligible_order = [item for item in available_order if item in eligible_ids]
+    if eligible_ids != expected_eligible_order or BASELINE_BACKEND not in eligible_ids:
+        raise ValueError("eligible backend order/uniqueness mismatch")
+    specs = tuple(_qualify_backend(registry, backend) for backend in eligible_ids)
+    if not _exact(report["negative_requests"], _negative_evidence(registry)):
+        raise ValueError("negative fail-closed evidence mismatch")
+    expected_pairs = [
+        (backend, engine) for backend in eligible_ids for engine in engines
+    ]
+    observed_pairs: list[tuple[str, str]] = []
+    semantics: dict[tuple[str, str], Any] = {}
+    if type(report["correctness"]) is not list:
+        raise ValueError("correctness list type mismatch")
+    for row in report["correctness"]:
+        keys = {
+            "backend",
+            "engine",
+            "semantic",
+            "semantic_sha256",
+            "baseline_sha256",
+            "factory",
+        }
+        if (
+            type(row) is not dict
+            or set(row) != keys
+            or type(row["backend"]) is not str
+            or type(row["engine"]) is not str
+        ):
+            raise ValueError("correctness row schema/type mismatch")
+        pair = (row["backend"], row["engine"])
+        observed_pairs.append(pair)
+        semantics[pair] = row["semantic"]
+        if row["semantic_sha256"] != _sha(row["semantic"]) or row[
+            "baseline_sha256"
+        ] != _sha(row["semantic"]):
+            raise ValueError("correctness digest/parity mismatch")
+        factory = row["factory"]
+        if type(factory) is not dict or set(factory) != {
+            "calls",
+            "implementation_ids",
+            "implementation_module",
+            "implementation_type",
+        }:
+            raise ValueError("factory evidence schema mismatch")
+        if (
+            type(factory["calls"]) is not int
+            or factory["calls"] <= 0
+            or type(factory["implementation_ids"]) is not list
+            or len(factory["implementation_ids"]) != factory["calls"]
+            or len(set(factory["implementation_ids"])) != factory["calls"]
+            or any(type(item) is not int for item in factory["implementation_ids"])
+        ):
+            raise ValueError("factory call/identity evidence mismatch")
+        spec = next(item for item in specs if item.id == row["backend"])
+        implementation = spec.loader()
+        if (
+            factory["implementation_module"] != implementation.__module__
+            or factory["implementation_type"] != implementation.__qualname__
+        ):
+            raise ValueError("factory backend provenance mismatch")
+    if observed_pairs != expected_pairs or len(set(observed_pairs)) != len(
+        expected_pairs
+    ):
+        raise ValueError("correctness matrix order/uniqueness mismatch")
+    for backend in eligible_ids:
+        for engine in engines:
+            if not _exact(
+                semantics[(backend, engine)], semantics[(BASELINE_BACKEND, engine)]
+            ):
+                raise ValueError("exact py_boundary semantic parity mismatch")
+    if (
+        type(report["benchmarks"]) is not list
+        or type(report["confirmation"]) is not list
+    ):
+        raise ValueError("benchmark/confirmation list type mismatch")
+    for row in report["benchmarks"]:
+        _verify_benchmark_row(row, blocks)
+        if row["phase"] != "initial":
+            raise ValueError("benchmark phase mismatch")
+        expected_sha = _sha(semantics[(BASELINE_BACKEND, row["engine"])])
+        if row["semantic_sha256"] != expected_sha:
+            raise ValueError("timed semantic digest mismatch")
+    expected_initial = [
+        (backend, engine) for backend in eligible_ids for engine in engines
+    ]
+    observed_initial = [(row["backend"], row["engine"]) for row in report["benchmarks"]]
+    if observed_initial != expected_initial or len(set(observed_initial)) != len(
+        expected_initial
+    ):
+        raise ValueError("benchmark matrix order/uniqueness mismatch")
+    initial_gate = _gate(specs, report["benchmarks"], (), engines)
+    confirmation_pairs = [
+        (row.get("backend"), row.get("engine")) if type(row) is dict else (None, None)
+        for row in report["confirmation"]
+    ]
+    expected_confirmation = [
+        (backend, engine)
+        for backend in initial_gate["initial_candidates"]
+        for engine in engines
+    ]
+    if confirmation_pairs != expected_confirmation or len(
+        set(confirmation_pairs)
+    ) != len(expected_confirmation):
+        raise ValueError("confirmation matrix order/uniqueness mismatch")
+    for row in report["confirmation"]:
+        _verify_benchmark_row(row, blocks)
+        if row["phase"] != "confirmation":
+            raise ValueError("benchmark phase mismatch")
+        expected_sha = _sha(semantics[(BASELINE_BACKEND, row["engine"])])
+        if row["semantic_sha256"] != expected_sha:
+            raise ValueError("timed semantic digest mismatch")
+    expected_gate = _gate(specs, report["benchmarks"], report["confirmation"], engines)
+    if not _exact(report["gate"], expected_gate):
+        raise ValueError("recomputed gate mismatch")
+    if not _exact(report["provenance"], _provenance(specs)):
+        raise ValueError("source/runtime/backend/binary provenance mismatch")
+    if output.with_suffix(".md").read_text() != _markdown(report, digest):
+        raise ValueError("Markdown mismatch")
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--blocks", type=int, default=MINIMUM_BLOCKS)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("build/experiments/application-backend-matrix.json"),
+    )
+    parser.add_argument("--verify", action="store_true")
+    args = parser.parse_args()
+    if args.verify:
+        report = verify_artifacts(args.output)
+        print(f"verified {args.output}: {report['gate']['decision']}")
+        return
+    report = run_matrix(blocks=args.blocks)
+    paths = write_artifacts(report, args.output)
+    verify_artifacts(args.output)
+    print(f"{report['gate']['decision']}: {', '.join(str(path) for path in paths)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/performance/experiments/exact_batch_application_matrix.py
+++ b/tests/performance/experiments/exact_batch_application_matrix.py
@@ -1,0 +1,1167 @@
+#!/usr/bin/env python3
+"""Correctness-attested ExactBatch application-shape diagnostic.
+
+This experiment compares the packed native call with canonical ``cpp_boundary``
+scalar replay. It does not alter or replace any stable exact-batch gate and does
+not define a universal break-even threshold.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib
+import json
+import math
+import os
+import platform
+import random
+import statistics
+import struct
+import subprocess
+import sysconfig
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from treemendous import Span, create_range_set
+from treemendous.exact_batch import (
+    BatchLimits,
+    ExactBatchRangeSet,
+    MutationOpcode,
+)
+
+SCHEMA = "treemendous-exact-batch-application-matrix-v1"
+WORKLOAD_SCHEMA = "treemendous-exact-batch-application-workload-v1"
+BASELINE_BACKEND = "cpp_boundary"
+LOCAL_INTERVAL_COUNTS = (64, 1_000, 10_000)
+CLI_INTERVAL_COUNT = 100_000
+BATCH_SIZES = (1, 4, 16, 64)
+LOCALITIES = ("head", "middle", "tail")
+SHAPES = (
+    "strict_accept_reject",
+    "idempotent_real_noop",
+    "fragment_restore",
+    "coalesce_restore",
+    "wide_fanout",
+)
+MINIMUM_SAMPLES = 10
+BOOTSTRAP_RESAMPLES = 2_000
+BOOTSTRAP_SEED = 841_064
+BUILD_FLAG_NAMES = (
+    "BOOST_ROOT",
+    "TREE_MENDOUS_DISABLE_OPTIMIZATIONS",
+    "TREE_MENDOUS_GLIBCXX_DEBUG",
+    "TREE_MENDOUS_LOCAL_NATIVE",
+    "TREE_MENDOUS_SANITIZERS",
+    "TREE_MENDOUS_WITH_ICL",
+)
+RESOURCE_LIMITS = {
+    "max_operations": 64,
+    "max_live_intervals": 100_005,
+    "max_changed_spans": 1_000_000,
+    "max_result_bytes": 64 * 1024 * 1024,
+    "max_work_units": 10_000_000,
+}
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+_OPERATION = struct.Struct("@qqq")
+
+Operation = tuple[int, int, int]
+
+
+@dataclass(frozen=True)
+class CaseDefinition:
+    """One deterministic matrix case, including untimed state setup."""
+
+    case_id: str
+    interval_count: int
+    batch_size: int
+    locality: str
+    shape: str
+    domain: tuple[tuple[int, int], ...]
+    setup: tuple[Operation, ...]
+    operations: tuple[Operation, ...]
+    fanout: int
+
+
+def _checksum(value: Any) -> str:
+    encoded = json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"diagnostic JSON contains duplicate key: {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_non_finite(value: str) -> None:
+    raise ValueError(f"diagnostic JSON contains non-finite number: {value}")
+
+
+def _validate_finite_numbers(value: Any) -> None:
+    if type(value) is float and not math.isfinite(value):
+        raise ValueError("diagnostic JSON contains non-finite number")
+    if isinstance(value, dict):
+        for item in value.values():
+            _validate_finite_numbers(item)
+    elif isinstance(value, list):
+        for item in value:
+            _validate_finite_numbers(item)
+
+
+def _json_exact_equal(actual: Any, expected: Any) -> bool:
+    """Compare reconstructed JSON values without Python numeric coercion."""
+    if type(actual) is not type(expected):
+        return False
+    if isinstance(actual, dict):
+        return actual.keys() == expected.keys() and all(
+            _json_exact_equal(actual[key], expected[key]) for key in actual
+        )
+    if isinstance(actual, list):
+        return len(actual) == len(expected) and all(
+            _json_exact_equal(left, right)
+            for left, right in zip(actual, expected, strict=True)
+        )
+    return bool(actual == expected)
+
+
+def _components(count: int) -> tuple[tuple[int, int], ...]:
+    origin = -4 * count
+    return tuple((origin + 8 * index, origin + 8 * index + 6) for index in range(count))
+
+
+def _wide_components(
+    interval_count: int, locality: str
+) -> tuple[tuple[tuple[int, int], ...], tuple[Operation, ...], tuple[int, int], int]:
+    fanout = min(8, interval_count)
+    component_count = interval_count - fanout + 1
+    wide_index = _local_index(component_count, locality)
+    cursor = -4 * interval_count
+    domain: list[tuple[int, int]] = []
+    setup: list[Operation] = []
+    wide_span = (0, 0)
+    for index in range(component_count):
+        if index == wide_index:
+            lower = cursor
+            upper = lower + 2 * fanout - 1
+            domain.append((lower, upper))
+            setup.extend(
+                (
+                    MutationOpcode.DISCARD_REQUIRE_COVERED,
+                    lower + offset,
+                    lower + offset + 1,
+                )
+                for offset in range(1, 2 * fanout - 1, 2)
+            )
+            wide_span = (lower, upper)
+            cursor = upper + 2
+        else:
+            domain.append((cursor, cursor + 6))
+            cursor += 8
+    return tuple(domain), tuple(setup), wide_span, fanout
+
+
+def _local_index(count: int, locality: str) -> int:
+    if locality == "head":
+        return 0
+    if locality == "middle":
+        return count // 2
+    if locality == "tail":
+        return count - 1
+    raise ValueError(f"unsupported locality: {locality}")
+
+
+def _repeat_cycle(
+    cycle: tuple[Operation, ...], batch_size: int
+) -> tuple[Operation, ...]:
+    return tuple(cycle[index % len(cycle)] for index in range(batch_size))
+
+
+def case_definition(
+    interval_count: int,
+    batch_size: int,
+    shape: str,
+    locality: str,
+) -> CaseDefinition:
+    """Generate one signed-coordinate, half-open application-shaped trace."""
+    if interval_count < 4:
+        raise ValueError("interval_count must be at least four")
+    if batch_size not in BATCH_SIZES:
+        raise ValueError(f"unsupported batch size: {batch_size}")
+    if shape not in SHAPES:
+        raise ValueError(f"unsupported shape: {shape}")
+    if locality not in LOCALITIES:
+        raise ValueError(f"unsupported locality: {locality}")
+
+    component_count = (
+        interval_count - 1 if shape == "coalesce_restore" else interval_count
+    )
+    domain = _components(component_count)
+    target_index = _local_index(component_count, locality)
+    lower, upper = domain[target_index]
+    setup: tuple[Operation, ...] = ()
+    fanout = 1
+
+    if shape == "strict_accept_reject":
+        span = (lower + 2, lower + 4)
+        cycle = (
+            (MutationOpcode.DISCARD_REQUIRE_COVERED, *span),
+            (MutationOpcode.DISCARD_REQUIRE_COVERED, *span),
+            (MutationOpcode.ADD, *span),
+            (MutationOpcode.ADD, *span),
+        )
+    elif shape == "idempotent_real_noop":
+        span = (lower + 2, lower + 4)
+        cycle = (
+            (MutationOpcode.DISCARD, *span),
+            (MutationOpcode.DISCARD, *span),
+            (MutationOpcode.ADD, *span),
+            (MutationOpcode.ADD, *span),
+        )
+    elif shape == "fragment_restore":
+        left = (lower + 1, lower + 2)
+        right = (upper - 2, upper - 1)
+        cycle = (
+            (MutationOpcode.DISCARD, *left),
+            (MutationOpcode.ADD, *left),
+            (MutationOpcode.DISCARD_REQUIRE_COVERED, *right),
+            (MutationOpcode.ADD, *right),
+        )
+    elif shape == "coalesce_restore":
+        gap = (lower + 2, lower + 4)
+        setup = ((MutationOpcode.DISCARD_REQUIRE_COVERED, *gap),)
+        cycle = (
+            (MutationOpcode.ADD, *gap),
+            (MutationOpcode.DISCARD_REQUIRE_COVERED, *gap),
+            (MutationOpcode.ADD, *gap),
+            (MutationOpcode.DISCARD_REQUIRE_COVERED, *gap),
+        )
+    else:
+        domain, setup, wide_span, fanout = _wide_components(interval_count, locality)
+        start, end = wide_span
+        cycle = (
+            (MutationOpcode.DISCARD, start, end),
+            (MutationOpcode.ADD, start, end),
+            (MutationOpcode.DISCARD_REQUIRE_COVERED, start, end),
+            (MutationOpcode.ADD, start, end),
+        )
+
+    operations = _repeat_cycle(cycle, batch_size)
+    case_id = f"n{interval_count}-b{batch_size}-{shape}-{locality}"
+    return CaseDefinition(
+        case_id,
+        interval_count,
+        batch_size,
+        locality,
+        shape,
+        domain,
+        setup,
+        operations,
+        fanout,
+    )
+
+
+def _packed(operations: tuple[Operation, ...]) -> bytes:
+    return b"".join(
+        _OPERATION.pack(int(opcode), start, end) for opcode, start, end in operations
+    )
+
+
+def _apply_scalar(manager: Any, operations: tuple[Operation, ...]) -> tuple[Any, ...]:
+    results = []
+    for opcode, start, end in operations:
+        span = Span(start, end)
+        if opcode == MutationOpcode.ADD:
+            results.append(manager.add(span))
+        else:
+            results.append(
+                manager.discard(
+                    span,
+                    require_covered=(opcode == MutationOpcode.DISCARD_REQUIRE_COVERED),
+                )
+            )
+    return tuple(results)
+
+
+def _geometry(snapshot: Any) -> tuple[tuple[int, int], ...]:
+    return tuple((interval.start, interval.end) for interval in snapshot.intervals)
+
+
+def _serialized_results(results: tuple[Any, ...]) -> list[dict[str, Any]]:
+    return [
+        {
+            "changed": [[span.start, span.end] for span in result.changed],
+            "changed_length": result.changed_length,
+            "fully_covered": result.fully_covered,
+        }
+        for result in results
+    ]
+
+
+def _new_scalar(case: CaseDefinition) -> Any:
+    manager = create_range_set(
+        case.domain,
+        backend=BASELINE_BACKEND,
+        initially_available=True,
+    )
+    _apply_scalar(manager, case.setup)
+    return manager
+
+
+def _new_exact(case: CaseDefinition) -> ExactBatchRangeSet:
+    limits = BatchLimits(**RESOURCE_LIMITS)
+    if asdict(limits) != RESOURCE_LIMITS:
+        raise AssertionError("diagnostic limits no longer match BatchLimits")
+    manager = ExactBatchRangeSet(case.domain, initially_available=True, limits=limits)
+    if case.setup:
+        manager.mutate_packed(_packed(case.setup)).materialize()
+    return manager
+
+
+def _oracle_evidence(
+    case: CaseDefinition,
+) -> tuple[tuple[Any, ...], tuple[tuple[int, int], ...], dict[str, int]]:
+    manager = _new_scalar(case)
+    if len(manager.snapshot().intervals) != case.interval_count:
+        raise AssertionError(f"{case.case_id}: setup has wrong live interval count")
+    work_units = 0
+    results: list[Any] = []
+    for operation in case.operations:
+        work_units += 1 + len(manager.snapshot().intervals)
+        results.extend(_apply_scalar(manager, (operation,)))
+    result_tuple = tuple(results)
+    final_geometry = _geometry(manager.snapshot())
+    declaration = {
+        "logical_rows": case.batch_size,
+        "initial_live_intervals": case.interval_count,
+        "final_live_intervals": len(final_geometry),
+        "changed_spans": sum(len(result.changed) for result in result_tuple),
+        "changed_length": sum(result.changed_length for result in result_tuple),
+        "mutating_rows": sum(bool(result.changed) for result in result_tuple),
+        "noop_rows": sum(not result.changed for result in result_tuple),
+        "strict_accepted_rows": sum(
+            operation[0] == MutationOpcode.DISCARD_REQUIRE_COVERED
+            and result.fully_covered
+            for operation, result in zip(case.operations, result_tuple, strict=True)
+        ),
+        "strict_rejected_rows": sum(
+            operation[0] == MutationOpcode.DISCARD_REQUIRE_COVERED
+            and not result.fully_covered
+            for operation, result in zip(case.operations, result_tuple, strict=True)
+        ),
+        "native_work_units": work_units,
+        "fanout": case.fanout,
+    }
+    return result_tuple, final_geometry, declaration
+
+
+def _case_manifest(case: CaseDefinition) -> dict[str, Any]:
+    results, final_geometry, work = _oracle_evidence(case)
+    oracle = {
+        "results": _serialized_results(results),
+        "final_geometry": [list(span) for span in final_geometry],
+    }
+    body = {
+        "case_id": case.case_id,
+        "interval_count": case.interval_count,
+        "batch_size": case.batch_size,
+        "shape": case.shape,
+        "locality": case.locality,
+        "domain_generator": (
+            "one wide component fragmented by unit setup holes"
+            if case.shape == "wide_fanout"
+            else "component_i=[-4*C+8*i,-4*C+8*i+6)"
+        ),
+        "domain_components": len(case.domain),
+        "setup_operations": [list(map(int, row)) for row in case.setup],
+        "operations": [list(map(int, row)) for row in case.operations],
+        "packed_input_bytes": len(_packed(case.operations)),
+        "work": work,
+        "oracle_digest": _checksum(oracle),
+    }
+    return {**body, "digest": _checksum(body)}
+
+
+def workload_manifest(cases: tuple[CaseDefinition, ...]) -> dict[str, Any]:
+    """Return the exact generated workload plus a whole-manifest digest."""
+    body = {
+        "schema": WORKLOAD_SCHEMA,
+        "coordinate_semantics": "signed-int64 half-open integer intervals",
+        "cases": [_case_manifest(case) for case in cases],
+    }
+    return {**body, "digest": _checksum(body)}
+
+
+def _packed_result_bytes(result: Any) -> int:
+    return sum(
+        view.nbytes
+        for view in (
+            result.changed_offsets,
+            result.changed_spans,
+            result.changed_lengths,
+            result.fully_covered,
+        )
+    )
+
+
+def attest_case(
+    case: CaseDefinition,
+) -> tuple[tuple[Any, ...], tuple[tuple[int, int], ...], int, dict[str, int]]:
+    """Prove packed rows and final state against canonical scalar replay."""
+    expected_rows, expected_final, work = _oracle_evidence(case)
+    exact = _new_exact(case)
+    initial = exact.snapshot()
+    if len(initial.intervals) != case.interval_count:
+        raise AssertionError(f"{case.case_id}: exact setup has wrong state count")
+    packed_result = exact.mutate_packed(_packed(case.operations))
+    exact_rows = packed_result.materialize()
+    exact_final = _geometry(exact.snapshot())
+    if exact_rows != expected_rows:
+        raise AssertionError(f"{case.case_id}: packed rows differ from cpp_boundary")
+    if exact_final != expected_final:
+        raise AssertionError(f"{case.case_id}: final state differs from cpp_boundary")
+    return expected_rows, expected_final, _packed_result_bytes(packed_result), work
+
+
+def _percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    position = fraction * (len(ordered) - 1)
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = position - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def _median_confidence(values: list[float]) -> list[float]:
+    rng = random.Random(BOOTSTRAP_SEED)
+    bootstrapped = [
+        statistics.median(rng.choices(values, k=len(values)))
+        for _ in range(BOOTSTRAP_RESAMPLES)
+    ]
+    return [_percentile(bootstrapped, 0.025), _percentile(bootstrapped, 0.975)]
+
+
+def _measure_case(case: CaseDefinition, samples: int) -> dict[str, Any]:
+    expected_rows, expected_final, packed_bytes, work = attest_case(case)
+    packed_operations = _packed(case.operations)
+    exact_samples: list[int] = []
+    scalar_samples: list[int] = []
+
+    for sample_index in range(samples):
+        exact = _new_exact(case)
+        scalar = _new_scalar(case)
+        if sample_index % 2 == 0:
+            started = time.perf_counter_ns()
+            packed_result = exact.mutate_packed(packed_operations)
+            exact_elapsed = time.perf_counter_ns() - started
+            started = time.perf_counter_ns()
+            scalar_rows = _apply_scalar(scalar, case.operations)
+            scalar_elapsed = time.perf_counter_ns() - started
+        else:
+            started = time.perf_counter_ns()
+            scalar_rows = _apply_scalar(scalar, case.operations)
+            scalar_elapsed = time.perf_counter_ns() - started
+            started = time.perf_counter_ns()
+            packed_result = exact.mutate_packed(packed_operations)
+            exact_elapsed = time.perf_counter_ns() - started
+
+        exact_rows = packed_result.materialize()
+        if exact_rows != expected_rows or scalar_rows != expected_rows:
+            raise AssertionError(f"{case.case_id}: timed result diverged from oracle")
+        if _geometry(exact.snapshot()) != expected_final:
+            raise AssertionError(f"{case.case_id}: timed packed final state diverged")
+        if _geometry(scalar.snapshot()) != expected_final:
+            raise AssertionError(f"{case.case_id}: timed scalar final state diverged")
+        if _packed_result_bytes(packed_result) != packed_bytes:
+            raise AssertionError(f"{case.case_id}: packed result byte count changed")
+        exact_samples.append(exact_elapsed)
+        scalar_samples.append(scalar_elapsed)
+
+    ratios = [
+        exact / scalar
+        for exact, scalar in zip(exact_samples, scalar_samples, strict=True)
+    ]
+    return {
+        "case_id": case.case_id,
+        "interval_count": case.interval_count,
+        "batch_size": case.batch_size,
+        "shape": case.shape,
+        "locality": case.locality,
+        "exact_latency_ns_samples": exact_samples,
+        "exact_latency_ns_median": statistics.median(exact_samples),
+        "exact_latency_ns_confidence_95": _median_confidence(
+            [float(value) for value in exact_samples]
+        ),
+        "scalar_latency_ns_samples": scalar_samples,
+        "scalar_latency_ns_median": statistics.median(scalar_samples),
+        "scalar_latency_ns_confidence_95": _median_confidence(
+            [float(value) for value in scalar_samples]
+        ),
+        "paired_exact_over_scalar_samples": ratios,
+        "paired_exact_over_scalar_median": statistics.median(ratios),
+        "paired_exact_over_scalar_confidence_95": _median_confidence(ratios),
+        "packed_input_bytes": len(packed_operations),
+        "packed_result_bytes": packed_bytes,
+        "work": work,
+        "validated_sample_count": samples,
+    }
+
+
+def _git_metadata() -> dict[str, Any]:
+    def git(*arguments: str) -> str:
+        return subprocess.run(
+            ["git", *arguments],
+            cwd=_REPOSITORY_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+
+    try:
+        commit = git("rev-parse", "HEAD").strip()
+        head_tree = git("rev-parse", "HEAD^{tree}").strip()
+        status = git("status", "--porcelain=v1")
+        diff = git("diff", "--binary", "HEAD")
+        staged = [
+            line for line in git("diff", "--cached", "--name-only").splitlines() if line
+        ]
+        changed_paths = sorted(
+            line
+            for line in git(
+                "ls-files", "--modified", "--others", "--exclude-standard"
+            ).splitlines()
+            if line
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return {
+            "commit": "unknown",
+            "head_tree": "unknown",
+            "clean_worktree": False,
+            "changed_paths": [],
+            "staged_files": [],
+            "source_state_sha256": "unknown",
+        }
+    source_state = hashlib.sha256((status + diff).encode())
+    for relative in changed_paths:
+        path = _REPOSITORY_ROOT / relative
+        source_state.update(relative.encode())
+        source_state.update(b"\0")
+        if path.is_file():
+            source_state.update(hashlib.sha256(path.read_bytes()).digest())
+    return {
+        "commit": commit,
+        "head_tree": head_tree,
+        "clean_worktree": not status,
+        "changed_paths": changed_paths,
+        "staged_files": staged,
+        "source_state_sha256": source_state.hexdigest(),
+    }
+
+
+def _compiler_version() -> str:
+    compiler = os.environ.get("CXX", "c++")
+    try:
+        completed = subprocess.run(
+            [compiler, "--version"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return "unavailable"
+    return completed.stdout.splitlines()[0] if completed.stdout else "unavailable"
+
+
+def _source_metadata(relative: str) -> dict[str, str]:
+    path = (_REPOSITORY_ROOT / relative).resolve()
+    return {
+        "path": relative,
+        "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+    }
+
+
+def _extension_metadata(module_name: str) -> dict[str, str]:
+    module = importlib.import_module(module_name)
+    raw_path = getattr(module, "__file__", None)
+    if not isinstance(raw_path, str):
+        raise RuntimeError(f"native extension {module_name!r} has no file")
+    path = Path(raw_path).resolve()
+    try:
+        display_path = str(path.relative_to(_REPOSITORY_ROOT))
+    except ValueError:
+        display_path = str(path)
+    return {
+        "path": display_path,
+        "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+    }
+
+
+def _runtime_metadata() -> dict[str, Any]:
+    return {
+        "python_version": platform.python_version(),
+        "python_implementation": platform.python_implementation(),
+        "python_compiler": platform.python_compiler(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "architecture": platform.architecture()[0],
+        "processor": platform.processor() or "unknown",
+        "cpu_count": os.cpu_count() or 0,
+    }
+
+
+def _build_metadata() -> dict[str, Any]:
+    return {
+        "command": os.environ.get(
+            "TREE_MENDOUS_BUILD_COMMAND", "python setup.py build_ext --inplace"
+        ),
+        "cxx": os.environ.get("CXX", "c++"),
+        "cxx_version": _compiler_version(),
+        "cc": str(sysconfig.get_config_var("CC") or "unknown"),
+        "cflags": str(sysconfig.get_config_var("CFLAGS") or "unknown"),
+        "flags": {name: os.environ.get(name, "") for name in BUILD_FLAG_NAMES},
+    }
+
+
+def _backend_metadata() -> dict[str, dict[str, Any]]:
+    exact = ExactBatchRangeSet((0, 1), initially_available=False)
+    exact_type = type(exact._manager)
+    baseline = create_range_set(
+        (0, 1), backend=BASELINE_BACKEND, initially_available=False
+    )
+    baseline_type = type(baseline._adapter.implementation)
+    return {
+        "exact_batch": {
+            "id": "exact_batch",
+            "module": exact_type.__module__,
+            "type": exact_type.__qualname__,
+            "extension": _extension_metadata("treemendous.cpp._exact_batch"),
+        },
+        BASELINE_BACKEND: {
+            "id": BASELINE_BACKEND,
+            "module": baseline_type.__module__,
+            "type": baseline_type.__qualname__,
+            "extension": _extension_metadata("treemendous.cpp.boundary"),
+        },
+    }
+
+
+def _provenance() -> dict[str, Any]:
+    return {
+        "source": _git_metadata(),
+        "sources": [
+            _source_metadata(
+                "tests/performance/experiments/exact_batch_application_matrix.py"
+            ),
+            _source_metadata("treemendous/exact_batch.py"),
+        ],
+        "runtime": _runtime_metadata(),
+        "build": _build_metadata(),
+        "backends": _backend_metadata(),
+    }
+
+
+def _summary(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    break_even: dict[str, int | None] = {}
+    for interval_count in sorted({row["interval_count"] for row in rows}):
+        for shape in SHAPES:
+            for locality in LOCALITIES:
+                matching = sorted(
+                    (
+                        row
+                        for row in rows
+                        if row["interval_count"] == interval_count
+                        and row["shape"] == shape
+                        and row["locality"] == locality
+                    ),
+                    key=lambda row: row["batch_size"],
+                )
+                winner = next(
+                    (
+                        row["batch_size"]
+                        for row in matching
+                        if row["paired_exact_over_scalar_median"] <= 1.0
+                    ),
+                    None,
+                )
+                break_even[f"n{interval_count}-{shape}-{locality}"] = winner
+    return {
+        "observed_median_break_even_batch": break_even,
+        "cells_exact_faster_with_95_ci": sum(
+            row["paired_exact_over_scalar_confidence_95"][1] < 1.0 for row in rows
+        ),
+        "cells_scalar_faster_with_95_ci": sum(
+            row["paired_exact_over_scalar_confidence_95"][0] > 1.0 for row in rows
+        ),
+        "cells_inconclusive": sum(
+            row["paired_exact_over_scalar_confidence_95"][0]
+            <= 1.0
+            <= row["paired_exact_over_scalar_confidence_95"][1]
+            for row in rows
+        ),
+    }
+
+
+def _cases(
+    interval_counts: tuple[int, ...],
+    batch_sizes: tuple[int, ...],
+    shapes: tuple[str, ...],
+    localities: tuple[str, ...],
+) -> tuple[CaseDefinition, ...]:
+    return tuple(
+        case_definition(interval_count, batch_size, shape, locality)
+        for interval_count in interval_counts
+        for batch_size in batch_sizes
+        for shape in shapes
+        for locality in localities
+    )
+
+
+def _run_matrix(
+    *,
+    profile: str,
+    samples: int,
+    interval_counts: tuple[int, ...],
+    batch_sizes: tuple[int, ...],
+    shapes: tuple[str, ...],
+    localities: tuple[str, ...],
+) -> dict[str, Any]:
+    if samples < MINIMUM_SAMPLES:
+        raise ValueError(f"diagnostic requires at least {MINIMUM_SAMPLES} samples")
+    cases = _cases(interval_counts, batch_sizes, shapes, localities)
+    manifest = workload_manifest(cases)
+    rows = [_measure_case(case, samples) for case in cases]
+    return {
+        "schema": SCHEMA,
+        "diagnostic_only": True,
+        "provenance": _provenance(),
+        "methodology": {
+            "profile": profile,
+            "samples": samples,
+            "bootstrap_resamples": BOOTSTRAP_RESAMPLES,
+            "bootstrap_seed": BOOTSTRAP_SEED,
+            "interval_counts": list(interval_counts),
+            "batch_sizes": list(batch_sizes),
+            "shapes": list(shapes),
+            "localities": list(localities),
+            "timed_exact_layer": "one mutate_packed call through packed-result construction",
+            "timed_scalar_layer": "ordered cpp_boundary RangeSet add/discard replay",
+            "excluded": "manager/domain setup, operation packing, scalar oracle construction, result materialization, snapshots, validation, and artifact writing",
+            "pair_order": "alternated exact-first and scalar-first by sample index",
+            "claim_scope": "bounded diagnostic cells only; no universal threshold or stable gate",
+        },
+        "resource_limits": dict(RESOURCE_LIMITS),
+        "workload_manifest": manifest,
+        "rows": rows,
+        "summary": _summary(rows),
+        "existing_exact_gates_changed": False,
+    }
+
+
+def run_benchmark(
+    *,
+    profile: str = "smoke",
+    samples: int = MINIMUM_SAMPLES,
+    include_100000: bool = False,
+) -> dict[str, Any]:
+    """Run a smoke or complete local diagnostic profile."""
+    interval_counts: tuple[int, ...]
+    batch_sizes: tuple[int, ...]
+    localities: tuple[str, ...]
+    if profile == "smoke":
+        interval_counts = (64,)
+        batch_sizes = (1, 16)
+        localities = ("head", "tail")
+    elif profile == "local":
+        interval_counts = LOCAL_INTERVAL_COUNTS
+        batch_sizes = BATCH_SIZES
+        localities = LOCALITIES
+    else:
+        raise ValueError(f"unsupported profile: {profile}")
+    if include_100000:
+        interval_counts = (*interval_counts, CLI_INTERVAL_COUNT)
+    return _run_matrix(
+        profile=profile,
+        samples=samples,
+        interval_counts=interval_counts,
+        batch_sizes=batch_sizes,
+        shapes=SHAPES,
+        localities=localities,
+    )
+
+
+def render_markdown(report: dict[str, Any], digest: str) -> str:
+    """Render a deterministic human-readable companion."""
+    source = report["provenance"]["source"]
+    lines = [
+        "# Exact-batch application matrix (diagnostic)",
+        "",
+        "This bounded observation does not change stable exact-batch gates and is not a universal performance claim.",
+        "",
+        f"- Commit: `{source['commit']}`",
+        f"- Clean worktree: `{str(source['clean_worktree']).lower()}`",
+        f"- Workload digest: `{report['workload_manifest']['digest']}`",
+        f"- JSON SHA-256: `{digest}`",
+        f"- Samples per cell: `{report['methodology']['samples']}`",
+        "",
+        "| N | B | Shape | Locality | Packed median (us) | Scalar median (us) | Packed/scalar median | 95% paired CI | Result bytes | Work units |",
+        "|---:|---:|---|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in report["rows"]:
+        confidence = row["paired_exact_over_scalar_confidence_95"]
+        lines.append(
+            f"| {row['interval_count']} | {row['batch_size']} | {row['shape']} | "
+            f"{row['locality']} | {row['exact_latency_ns_median'] / 1_000:.3f} | "
+            f"{row['scalar_latency_ns_median'] / 1_000:.3f} | "
+            f"{row['paired_exact_over_scalar_median']:.3f} | "
+            f"[{confidence[0]:.3f}, {confidence[1]:.3f}] | "
+            f"{row['packed_result_bytes']} | {row['work']['native_work_units']} |"
+        )
+    summary = report["summary"]
+    lines.extend(
+        (
+            "",
+            f"Cells with packed faster at 95% CI: {summary['cells_exact_faster_with_95_ci']}.",
+            f"Cells with scalar faster at 95% CI: {summary['cells_scalar_faster_with_95_ci']}.",
+            f"Inconclusive cells: {summary['cells_inconclusive']}.",
+        )
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_artifacts(report: dict[str, Any], output: Path) -> tuple[Path, Path, Path]:
+    """Atomically write canonical JSON, Markdown, and SHA-256 sidecar."""
+    if output.suffix != ".json":
+        raise ValueError("diagnostic output must use a .json suffix")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (json.dumps(report, indent=2, sort_keys=True) + "\n").encode()
+    digest = hashlib.sha256(encoded).hexdigest()
+    markdown = output.with_suffix(".md")
+    checksum = Path(f"{output}.sha256")
+    for destination, contents in (
+        (output, encoded),
+        (markdown, render_markdown(report, digest).encode()),
+        (checksum, f"{digest}  {output.name}\n".encode()),
+    ):
+        temporary = destination.with_name(f".{destination.name}.tmp")
+        temporary.write_bytes(contents)
+        temporary.replace(destination)
+    return output, markdown, checksum
+
+
+def _require_exact_keys(value: Any, keys: set[str], label: str) -> dict[str, Any]:
+    if type(value) is not dict or set(value) != keys:
+        raise ValueError(f"diagnostic {label} keys/type mismatch")
+    return value
+
+
+def _expected_profile_dimensions(methodology: dict[str, Any]) -> None:
+    profile = methodology["profile"]
+    include_large = methodology["interval_counts"][-1:] == [CLI_INTERVAL_COUNT]
+    if profile == "smoke":
+        counts = [64, *([CLI_INTERVAL_COUNT] if include_large else [])]
+        batches = [1, 16]
+        localities = ["head", "tail"]
+    elif profile == "local":
+        counts = [
+            *LOCAL_INTERVAL_COUNTS,
+            *([CLI_INTERVAL_COUNT] if include_large else []),
+        ]
+        batches = list(BATCH_SIZES)
+        localities = list(LOCALITIES)
+    else:
+        raise ValueError("diagnostic methodology profile is invalid")
+    if (
+        methodology["interval_counts"] != counts
+        or methodology["batch_sizes"] != batches
+        or methodology["shapes"] != list(SHAPES)
+        or methodology["localities"] != localities
+    ):
+        raise ValueError("diagnostic methodology matrix is invalid")
+
+
+def _expected_packed_result_bytes(case: CaseDefinition) -> int:
+    rows, _, work = _oracle_evidence(case)
+    if work["changed_spans"] != sum(len(row.changed) for row in rows):
+        raise AssertionError("oracle work declaration diverged")
+    return (
+        (case.batch_size + 1) * 8
+        + work["changed_spans"] * 16
+        + case.batch_size * 8
+        + case.batch_size
+    )
+
+
+def _verify_provenance(value: Any) -> None:
+    provenance = _require_exact_keys(
+        value, {"source", "sources", "runtime", "build", "backends"}, "provenance"
+    )
+    source = _require_exact_keys(
+        provenance["source"],
+        {
+            "commit",
+            "head_tree",
+            "clean_worktree",
+            "changed_paths",
+            "staged_files",
+            "source_state_sha256",
+        },
+        "source provenance",
+    )
+    if not _json_exact_equal(source, _git_metadata()):
+        raise ValueError("diagnostic source provenance does not match local checkout")
+    expected_sources = [
+        _source_metadata(
+            "tests/performance/experiments/exact_batch_application_matrix.py"
+        ),
+        _source_metadata("treemendous/exact_batch.py"),
+    ]
+    if not _json_exact_equal(provenance["sources"], expected_sources):
+        raise ValueError("diagnostic source file path/hash mismatch")
+    if not _json_exact_equal(provenance["runtime"], _runtime_metadata()):
+        raise ValueError("diagnostic runtime provenance does not match current runtime")
+    if not _json_exact_equal(provenance["build"], _build_metadata()):
+        raise ValueError("diagnostic build provenance does not match current build")
+    if not _json_exact_equal(provenance["backends"], _backend_metadata()):
+        raise ValueError(
+            "diagnostic backend/extension provenance does not match active backends"
+        )
+
+
+def verify_artifacts(output: Path) -> dict[str, Any]:
+    """Verify the diagnostic triplet, provenance, workload, and every derivation."""
+    markdown = output.with_suffix(".md")
+    checksum = Path(f"{output}.sha256")
+    for path in (output, markdown, checksum):
+        if not path.is_file():
+            raise ValueError(f"diagnostic artifact is missing: {path}")
+    encoded = output.read_bytes()
+    digest = hashlib.sha256(encoded).hexdigest()
+    if checksum.read_text() != f"{digest}  {output.name}\n":
+        raise ValueError("diagnostic checksum does not match JSON")
+    report = json.loads(
+        encoded,
+        object_pairs_hook=_reject_duplicate_keys,
+        parse_constant=_reject_non_finite,
+    )
+    if not isinstance(report, dict):
+        raise ValueError("diagnostic JSON root must be an object")
+    _validate_finite_numbers(report)
+    if encoded != (json.dumps(report, indent=2, sort_keys=True) + "\n").encode():
+        raise ValueError("diagnostic JSON is not canonical")
+    _require_exact_keys(
+        report,
+        {
+            "schema",
+            "diagnostic_only",
+            "provenance",
+            "methodology",
+            "resource_limits",
+            "workload_manifest",
+            "rows",
+            "summary",
+            "existing_exact_gates_changed",
+        },
+        "report",
+    )
+    if report["schema"] != SCHEMA or report["diagnostic_only"] is not True:
+        raise ValueError("unexpected diagnostic schema")
+    if report["existing_exact_gates_changed"] is not False:
+        raise ValueError("existing exact gate declaration changed")
+    if not _json_exact_equal(report["resource_limits"], RESOURCE_LIMITS):
+        raise ValueError("diagnostic resource limits do not match")
+    _verify_provenance(report["provenance"])
+
+    methodology = _require_exact_keys(
+        report["methodology"],
+        {
+            "profile",
+            "samples",
+            "bootstrap_resamples",
+            "bootstrap_seed",
+            "interval_counts",
+            "batch_sizes",
+            "shapes",
+            "localities",
+            "timed_exact_layer",
+            "timed_scalar_layer",
+            "excluded",
+            "pair_order",
+            "claim_scope",
+        },
+        "methodology",
+    )
+    samples = methodology["samples"]
+    if type(samples) is not int or samples < MINIMUM_SAMPLES:
+        raise ValueError("diagnostic sample count is invalid")
+    fixed_method = {
+        "bootstrap_resamples": BOOTSTRAP_RESAMPLES,
+        "bootstrap_seed": BOOTSTRAP_SEED,
+        "timed_exact_layer": "one mutate_packed call through packed-result construction",
+        "timed_scalar_layer": "ordered cpp_boundary RangeSet add/discard replay",
+        "excluded": "manager/domain setup, operation packing, scalar oracle construction, result materialization, snapshots, validation, and artifact writing",
+        "pair_order": "alternated exact-first and scalar-first by sample index",
+        "claim_scope": "bounded diagnostic cells only; no universal threshold or stable gate",
+    }
+    if any(
+        not _json_exact_equal(methodology[key], value)
+        for key, value in fixed_method.items()
+    ):
+        raise ValueError("diagnostic fixed methodology does not match")
+    for key in ("interval_counts", "batch_sizes", "shapes", "localities"):
+        if type(methodology[key]) is not list:
+            raise ValueError("diagnostic methodology matrix type is invalid")
+    _expected_profile_dimensions(methodology)
+    expected_cases = _cases(
+        tuple(methodology["interval_counts"]),
+        tuple(methodology["batch_sizes"]),
+        tuple(methodology["shapes"]),
+        tuple(methodology["localities"]),
+    )
+
+    manifest = _require_exact_keys(
+        report["workload_manifest"],
+        {"schema", "coordinate_semantics", "cases", "digest"},
+        "workload manifest",
+    )
+    manifest_body = {key: value for key, value in manifest.items() if key != "digest"}
+    if manifest["digest"] != _checksum(manifest_body):
+        raise ValueError("workload digest does not match manifest")
+    if not _json_exact_equal(manifest, workload_manifest(expected_cases)):
+        raise ValueError("workload manifest does not match reconstructed matrix")
+
+    rows = report["rows"]
+    if type(rows) is not list or len(rows) != len(expected_cases):
+        raise ValueError("diagnostic rows do not match manifest")
+    row_keys = {
+        "case_id",
+        "interval_count",
+        "batch_size",
+        "shape",
+        "locality",
+        "exact_latency_ns_samples",
+        "exact_latency_ns_median",
+        "exact_latency_ns_confidence_95",
+        "scalar_latency_ns_samples",
+        "scalar_latency_ns_median",
+        "scalar_latency_ns_confidence_95",
+        "paired_exact_over_scalar_samples",
+        "paired_exact_over_scalar_median",
+        "paired_exact_over_scalar_confidence_95",
+        "packed_input_bytes",
+        "packed_result_bytes",
+        "work",
+        "validated_sample_count",
+    }
+    for row, case in zip(rows, expected_cases, strict=True):
+        _require_exact_keys(row, row_keys, "row")
+        expected_manifest = _case_manifest(case)
+        reconstructed = {
+            "case_id": expected_manifest["case_id"],
+            "interval_count": expected_manifest["interval_count"],
+            "batch_size": expected_manifest["batch_size"],
+            "shape": expected_manifest["shape"],
+            "locality": expected_manifest["locality"],
+            "packed_input_bytes": expected_manifest["packed_input_bytes"],
+            "packed_result_bytes": _expected_packed_result_bytes(case),
+            "work": expected_manifest["work"],
+            "validated_sample_count": samples,
+        }
+        if any(
+            not _json_exact_equal(row[key], value)
+            for key, value in reconstructed.items()
+        ):
+            raise ValueError("diagnostic row does not match reconstructed workload")
+        exact = row["exact_latency_ns_samples"]
+        scalar = row["scalar_latency_ns_samples"]
+        if (
+            type(exact) is not list
+            or type(scalar) is not list
+            or len(exact) != samples
+            or len(scalar) != samples
+            or any(type(value) is not int or value <= 0 for value in (*exact, *scalar))
+        ):
+            raise ValueError("diagnostic raw samples are invalid")
+        ratios = [left / right for left, right in zip(exact, scalar, strict=True)]
+        derived = {
+            "exact_latency_ns_median": statistics.median(exact),
+            "exact_latency_ns_confidence_95": _median_confidence(
+                [float(value) for value in exact]
+            ),
+            "scalar_latency_ns_median": statistics.median(scalar),
+            "scalar_latency_ns_confidence_95": _median_confidence(
+                [float(value) for value in scalar]
+            ),
+            "paired_exact_over_scalar_samples": ratios,
+            "paired_exact_over_scalar_median": statistics.median(ratios),
+            "paired_exact_over_scalar_confidence_95": _median_confidence(ratios),
+        }
+        for key, value in derived.items():
+            if not _json_exact_equal(row[key], value):
+                raise ValueError(
+                    f"diagnostic derived field {key} does not match raw samples"
+                )
+    _require_exact_keys(
+        report["summary"],
+        {
+            "observed_median_break_even_batch",
+            "cells_exact_faster_with_95_ci",
+            "cells_scalar_faster_with_95_ci",
+            "cells_inconclusive",
+        },
+        "summary",
+    )
+    if not _json_exact_equal(report["summary"], _summary(rows)):
+        raise ValueError("diagnostic summary does not match rows")
+    if markdown.read_text() != render_markdown(report, digest):
+        raise ValueError("diagnostic Markdown does not match JSON")
+    return report
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--profile", choices=("smoke", "local"), default="smoke")
+    parser.add_argument("--samples", type=int, default=MINIMUM_SAMPLES)
+    parser.add_argument("--include-100000", action="store_true")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("build/experiments/exact-batch-application-matrix.json"),
+    )
+    parser.add_argument(
+        "--verify",
+        action="store_true",
+        help="verify an existing triplet without running benchmark cells",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.verify:
+        report = verify_artifacts(args.output)
+        print(
+            f"verified cells={len(report['rows'])} "
+            f"workload={report['workload_manifest']['digest']} output={args.output}"
+        )
+        return 0
+    report = run_benchmark(
+        profile=args.profile,
+        samples=args.samples,
+        include_100000=args.include_100000,
+    )
+    paths = write_artifacts(report, args.output)
+    verify_artifacts(args.output)
+    print(
+        f"cells={len(report['rows'])} samples={args.samples} "
+        f"workload={report['workload_manifest']['digest']} output={paths[0]}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/performance/experiments/exact_batch_storage_matrix.py
+++ b/tests/performance/experiments/exact_batch_storage_matrix.py
@@ -1153,20 +1153,56 @@ def archive_metadata(report: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+class BaselineUnavailable(RuntimeError):
+    """The pinned baseline commit is absent and could not be fetched.
+
+    Raised when the durability proof cannot obtain the historical baseline
+    ``exact_batch_bindings.cpp`` — e.g. an offline shallow checkout that omits
+    the baseline commit — so callers can skip rather than hard-fail.
+    """
+
+
+_BASELINE_SOURCE_PATH = "treemendous/cpp/exact_batch_bindings.cpp"
+
+
+def _baseline_exact_batch_source() -> bytes:
+    """Return the baseline ``exact_batch_bindings.cpp`` bytes from Git history.
+
+    A shallow checkout (the CI default) omits the historical baseline commit, so
+    a best-effort fetch of that exact commit by SHA is attempted before giving
+    up; GitHub permits fetching a reachable SHA directly.
+    """
+    target = f"{BASELINE_FULL_COMMIT}:{_BASELINE_SOURCE_PATH}"
+
+    def show() -> bytes | None:
+        result = subprocess.run(
+            ["git", "show", target],
+            cwd=_REPOSITORY_ROOT,
+            capture_output=True,
+        )
+        return result.stdout if result.returncode == 0 else None
+
+    source = show()
+    if source is None:
+        subprocess.run(
+            ["git", "fetch", "--quiet", "--depth=1", "origin", BASELINE_FULL_COMMIT],
+            cwd=_REPOSITORY_ROOT,
+            capture_output=True,
+        )
+        source = show()
+    if source is None:
+        raise BaselineUnavailable(
+            f"baseline commit {BASELINE_FULL_COMMIT} is unavailable in this "
+            "checkout; cannot verify the segmented-patch durability proof"
+        )
+    return source
+
+
 def _verify_patch_application() -> None:
     patch = (_REPOSITORY_ROOT / SEGMENTED_PATCH).read_bytes()
     if hashlib.sha256(patch).hexdigest() != SEGMENTED_PATCH_SHA256:
         raise ValueError("segmented patch checksum mismatch")
-    source = subprocess.run(
-        [
-            "git",
-            "show",
-            f"{BASELINE_FULL_COMMIT}:treemendous/cpp/exact_batch_bindings.cpp",
-        ],
-        cwd=_REPOSITORY_ROOT,
-        check=True,
-        capture_output=True,
-    ).stdout
+    source = _baseline_exact_batch_source()
     if hashlib.sha256(source).hexdigest() != BASELINE_SOURCE_SHA256:
         raise ValueError("baseline exact-batch source checksum mismatch")
     with tempfile.TemporaryDirectory(prefix="treemendous-segmented-proof-") as raw:

--- a/tests/performance/experiments/exact_batch_storage_matrix.py
+++ b/tests/performance/experiments/exact_batch_storage_matrix.py
@@ -1,0 +1,1776 @@
+#!/usr/bin/env python3
+"""Strict vector-versus-segmented ExactBatch storage qualification evidence.
+
+The controller never imports either native extension.  It launches isolated
+workers with one checkout at the front of ``sys.path``, so the baseline and
+candidate may safely expose the same ``treemendous.cpp._exact_batch`` name.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib
+import json
+import math
+import os
+import platform
+import random
+import statistics
+import subprocess
+import sys
+import sysconfig
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+SCHEMA = "treemendous-exact-batch-storage-matrix-v1"
+WORKER_SCHEMA = "treemendous-exact-batch-storage-worker-v1"
+BASELINE_COMMIT = "2a384f7"
+DEFAULT_BASELINE = Path("/private/tmp/treemendous-e4-baseline")
+INTERVAL_COUNTS = (64, 1_000, 10_000, 100_000)
+BATCH_SIZES = (0, 1, 16, 256)
+LOCALITIES = ("head", "middle", "tail", "random")
+DIAGNOSTIC_SHAPES = (
+    *LOCALITIES,
+    "strict_only",
+    "duplicate_only",
+    "wide_1",
+    "wide_10",
+    "wide_100",
+)
+BLOCK_COUNTS = (127, 128, 129)
+BLOCK_SHAPES = ("split", "coalesce")
+PROMOTION_BLOCKS = 20
+BOOTSTRAP_RESAMPLES = 10_000
+BOOTSTRAP_SEED = 672_128
+K = 128
+ARCHIVE_NAME = "exact-batch-storage-segmented-tuned-rejection.json"
+ARCHIVE_SOURCE_ARTIFACT = (
+    "build/experiments/exact-batch-storage-small-n-tuning-smoke.json"
+)
+SEGMENTED_PATCH = Path(
+    "tests/performance/experiments/fixtures/exact_batch_segmented_tuned.patch"
+)
+SEGMENTED_PATCH_SHA256 = (
+    "6b30ab72f11aa4fd0eec8ed05f534e1b96a68a2918f1b605b5aba866d6adb432"
+)
+BASELINE_FULL_COMMIT = "2a384f74d29949fefd0286a147b30c1ef0a190d4"
+BASELINE_SOURCE_SHA256 = (
+    "0dbbacc095e142f82235a4e0e6f8c73d6bd2abe70d10965219482b09a86bf0c8"
+)
+SEGMENTED_SOURCE_SHA256 = (
+    "f5a368f011bcbbe9f49ba954b7014268ab7c711ecfb1d46b8b4d9da6a8858267"
+)
+BASELINE_BINARY_SHA256 = (
+    "f48e8c03fbfc7a6f434753d84b1545080bc5e9df123cb4fd30d9da28769fb372"
+)
+SEGMENTED_BINARY_SHA256 = (
+    "657bf80912e21be53572f10fd4375dbbdac1965e522072063f67ac24495002c5"
+)
+ARCHIVED_BASELINE_ROOT = "/private/tmp/treemendous-e4-baseline"
+ARCHIVED_CANDIDATE_ROOT = "/Users/joseph/dev/Tree-Mendous"
+ARCHIVED_TREE = "598588fba24adb869e5f26f16d9b6ec088a77e9c"
+ARCHIVED_BASELINE_STATE_SHA256 = (
+    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+ARCHIVED_CANDIDATE_STATE_SHA256 = (
+    "14674cdc450c8ba916946854ea38feeacc598ab6a3133d35179d016d9dc3f621"
+)
+ARCHIVED_BASELINE_CHANGED_PATHS_SHA256 = (
+    "4f53cda18c2baa0c0354bb5f9a3ecbe5ed12ab4d8e11ba873c2f11161202b945"
+)
+ARCHIVED_CANDIDATE_CHANGED_PATHS_SHA256 = (
+    "d6bfb847dbbd2cd197df0835c939217a8b61f5780aba0720724d0013e1379dba"
+)
+ARCHIVED_PACKAGE_SHA256 = (
+    "198f6ee8b1afd90a2fac90b925fe894e7ea3d2085aa16d9c3f2f0cc4df35b332"
+)
+ARCHIVED_BUILD = {
+    "cc": "clang",
+    "cflags": "-fno-strict-overflow -Wsign-compare -Wunreachable-code -DNDEBUG -g -O3 -Wall",
+    "command": "python setup.py build_ext --inplace --force",
+    "cxx": "c++",
+    "cxx_version": "Apple clang version 21.0.0 (clang-2100.1.1.101)",
+}
+ARCHIVED_RUNTIME = {
+    "architecture": "64bit",
+    "cpu_count": 18,
+    "implementation": "CPython",
+    "machine": "arm64",
+    "platform": "macOS-26.5.1-arm64-arm-64bit",
+    "python": "3.12.7",
+    "python_compiler": "Clang 16.0.0 (clang-1600.0.26.3)",
+}
+COUNTER_KEYS = (
+    "directory_entries_copied",
+    "blocks_rebuilt",
+    "intervals_copied",
+    "block_delta",
+    "generation",
+    "live_count",
+    "block_count",
+    "transient_estimated_bytes",
+    "retained_estimated_bytes",
+)
+RESOURCE_LIMITS = {
+    "max_operations": 1_000_000,
+    "max_live_intervals": 200_000,
+    "max_changed_spans": 2_000_000,
+    "max_result_bytes": 256 * 1024 * 1024,
+    "max_work_units": 100_000_000,
+}
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+Operation = tuple[int, int, int]
+
+
+def _checksum(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+    ).hexdigest()
+
+
+def _percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    position = fraction * (len(ordered) - 1)
+    lower = int(position)
+    upper = min(lower + 1, len(ordered) - 1)
+    weight = position - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def _ratio_summary(ratios: list[float]) -> dict[str, Any]:
+    rng = random.Random(BOOTSTRAP_SEED)
+    boot = [
+        statistics.median(rng.choices(ratios, k=len(ratios)))
+        for _ in range(BOOTSTRAP_RESAMPLES)
+    ]
+    return {
+        "candidate_over_vector_samples": ratios,
+        "candidate_over_vector_median": statistics.median(ratios),
+        "candidate_over_vector_confidence_95": [
+            _percentile(boot, 0.025),
+            _percentile(boot, 0.975),
+        ],
+    }
+
+
+def _packed(rows: tuple[Operation, ...]) -> bytes:
+    import struct
+
+    operation = struct.Struct("@qqq")
+    return b"".join(operation.pack(*row) for row in rows)
+
+
+def _regular_domain(count: int) -> tuple[tuple[int, int], ...]:
+    return tuple((index * 8, index * 8 + 6) for index in range(count))
+
+
+def _local_index(count: int, locality: str) -> int:
+    if locality == "head":
+        return 0
+    if locality == "middle":
+        return count // 2
+    if locality == "tail":
+        return count - 1
+    if locality == "random":
+        return random.Random(90_128 + count).randrange(count)
+    raise ValueError(locality)
+
+
+def _repeat_restorative(
+    cycle: tuple[Operation, ...], batch_size: int
+) -> tuple[Operation, ...]:
+    if batch_size == 0:
+        return ()
+    if batch_size == 1:
+        # A one-row restorative workload must be a no-op.
+        return (cycle[-1],)
+    return tuple(cycle[index % len(cycle)] for index in range(batch_size))
+
+
+def _diagnostic_definition(count: int, batch_size: int, shape: str) -> dict[str, Any]:
+    setup: tuple[Operation, ...] = ()
+    cycle: tuple[Operation, ...]
+    if shape.startswith("wide_"):
+        percentage = int(shape.removeprefix("wide_"))
+        width = 10_000
+        domain = (
+            (0, width),
+            *tuple((width + 2 + i * 8, width + 8 + i * 8) for i in range(count - 1)),
+        )
+        extent = width * percentage // 100
+        start = (width - extent) // 2
+        end = start + extent
+        cycle = ((1, start, end), (0, start, end), (0, start, end), (0, start, end))
+    else:
+        domain = _regular_domain(count)
+        index = _local_index(count, shape) if shape in LOCALITIES else count // 2
+        lower, _ = domain[index]
+        if shape == "strict_only":
+            setup = ((1, lower + 2, lower + 4),)
+            cycle = ((2, lower + 2, lower + 4),)  # strict rejection
+        elif shape == "duplicate_only":
+            cycle = ((0, lower + 1, lower + 2),)  # already covered
+        else:
+            cycle = (
+                (1, lower + 2, lower + 4),
+                (0, lower + 2, lower + 4),
+                (0, lower + 1, lower + 5),
+                (0, lower + 1, lower + 5),
+            )
+    rows = _repeat_restorative(cycle, batch_size)
+    return {
+        "case_id": f"matrix-n{count}-b{batch_size}-{shape}",
+        "interval_count": count,
+        "batch_size": batch_size,
+        "shape": shape,
+        "domain": domain,
+        "initially_available": True,
+        "setup": setup,
+        "rows": rows,
+    }
+
+
+def _block_definition(count: int, shape: str) -> dict[str, Any]:
+    domain = ((0, count * 4 + 8),)
+    setup = tuple((0, i * 4, i * 4 + 3) for i in range(count))
+    middle = (count // 2) * 4
+    if shape == "split":
+        rows = ((1, middle + 1, middle + 2), (0, middle + 1, middle + 2))
+    else:
+        rows = ((0, middle + 3, middle + 4), (1, middle + 3, middle + 4))
+    return {
+        "case_id": f"block-k{count}-{shape}",
+        "interval_count": count,
+        "batch_size": 2,
+        "shape": f"block_{shape}",
+        "domain": domain,
+        "initially_available": False,
+        "setup": setup,
+        "rows": rows,
+    }
+
+
+def diagnostic_definitions(profile: str = "full") -> tuple[dict[str, Any], ...]:
+    counts = INTERVAL_COUNTS if profile == "full" else (64,)
+    batches = BATCH_SIZES if profile == "full" else (0, 16)
+    cases = tuple(
+        _diagnostic_definition(count, batch, shape)
+        for count in counts
+        for batch in batches
+        for shape in DIAGNOSTIC_SHAPES
+    )
+    blocks = tuple(
+        _block_definition(count, shape)
+        for count in BLOCK_COUNTS
+        for shape in BLOCK_SHAPES
+    )
+    return (*cases, *blocks)
+
+
+def _restorative64() -> tuple[Operation, ...]:
+    rows: list[Operation] = []
+    for index in (0, 7, 23, 41):
+        start = index * 8
+        rows.extend(
+            (
+                (1, start + 2, start + 6),
+                (0, start + 2, start + 6),
+                (0, start + 1, start + 5),
+                (0, start + 1, start + 5),
+            )
+        )
+    return tuple(rows)
+
+
+def promotion_definitions(profile: str = "full") -> tuple[dict[str, Any], ...]:
+    counts = INTERVAL_COUNTS if profile == "full" else (64,)
+    cases: list[dict[str, Any]] = []
+    local_rows: tuple[Operation, ...] = tuple(
+        row
+        for index in (0, 33_333, 66_666, 99_999)
+        for row in (
+            (1, index * 8 + 2, index * 8 + 4),
+            (0, index * 8 + 2, index * 8 + 4),
+            (0, index * 8 + 1, index * 8 + 5),
+            (0, index * 8 + 1, index * 8 + 5),
+        )
+    )
+    for count in counts:
+        domain = _regular_domain(count)
+        if count == 64:
+            rows = _restorative64()
+            cases.append(
+                {
+                    "case_id": "promotion-restorative-n64-b16",
+                    "layer": "mutate",
+                    "interval_count": count,
+                    "domain": domain,
+                    "initially_available": True,
+                    "setup": (),
+                    "rows": rows,
+                    "iterations": 200,
+                }
+            )
+        if count == 100_000:
+            cases.append(
+                {
+                    "case_id": "promotion-local-n100000-b16",
+                    "layer": "mutate",
+                    "interval_count": count,
+                    "domain": domain,
+                    "initially_available": True,
+                    "setup": (),
+                    "rows": local_rows,
+                    "iterations": 3,
+                }
+            )
+            for percentage in (1, 10, 100):
+                definition = _diagnostic_definition(count, 16, f"wide_{percentage}")
+                cases.append(
+                    {
+                        **definition,
+                        "case_id": f"promotion-wide-n100000-p{percentage}",
+                        "layer": "mutate",
+                        "iterations": 3,
+                    }
+                )
+        cases.append(
+            {
+                "case_id": f"promotion-construction-n{count}",
+                "layer": "construction",
+                "interval_count": count,
+                "domain": domain,
+                "initially_available": True,
+                "setup": (),
+                "rows": (),
+                "iterations": 1,
+            }
+        )
+        cases.append(
+            {
+                "case_id": f"promotion-snapshot-n{count}",
+                "layer": "snapshot",
+                "interval_count": count,
+                "domain": domain,
+                "initially_available": True,
+                "setup": (),
+                "rows": (),
+                "iterations": 3 if count >= 10_000 else 30,
+            }
+        )
+        materialize_rows = (
+            (1, domain[count // 2][0] + 2, domain[count // 2][0] + 4),
+            (0, domain[count // 2][0] + 2, domain[count // 2][0] + 4),
+        )
+        cases.append(
+            {
+                "case_id": f"promotion-materialization-n{count}",
+                "layer": "materialization",
+                "interval_count": count,
+                "domain": domain,
+                "initially_available": True,
+                "setup": (),
+                "rows": materialize_rows,
+                "iterations": 100,
+            }
+        )
+    return tuple(cases)
+
+
+def _is_descendant(path: Path, root: Path) -> bool:
+    return path.resolve().is_relative_to(root.resolve())
+
+
+def _file_metadata(path: Path) -> dict[str, str]:
+    resolved = path.resolve()
+    return {
+        "path": str(resolved),
+        "sha256": hashlib.sha256(resolved.read_bytes()).hexdigest(),
+    }
+
+
+def _purge_checkout_imports(root: Path) -> None:
+    """Make the requested checkout the worker's only importable project root."""
+    requested = root.resolve()
+    current = _REPOSITORY_ROOT.resolve()
+    for name in tuple(sys.modules):
+        if (
+            name == "treemendous"
+            or name.startswith("treemendous.")
+            or name == "tests"
+            or name.startswith("tests.")
+        ):
+            del sys.modules[name]
+
+    retained: list[str] = []
+    for entry in sys.path:
+        resolved = Path(entry or os.getcwd()).resolve()
+        if resolved == requested:
+            continue
+        if _is_descendant(resolved, current) or _is_descendant(resolved, requested):
+            continue
+        retained.append(entry)
+    sys.path[:] = [str(requested), *retained]
+
+    # Editable installs register a meta-path finder from a site-packages .pth.
+    # Workers also start with -I -S, but remove any such finder defensively.
+    sys.meta_path[:] = [
+        finder
+        for finder in sys.meta_path
+        if not type(finder).__module__.startswith("__editable__")
+    ]
+    for name in tuple(sys.modules):
+        if name.startswith("__editable__"):
+            del sys.modules[name]
+    sys.path_importer_cache.clear()
+    importlib.invalidate_caches()
+
+
+def _worker_imports(root: Path) -> tuple[Any, Any, Any, Any, Any]:
+    from treemendous import Span, create_range_set
+    from treemendous.exact_batch import BatchLimits, ExactBatchRangeSet, MutationOpcode
+
+    return Span, create_range_set, BatchLimits, ExactBatchRangeSet, MutationOpcode
+
+
+def _import_metadata(root: Path) -> dict[str, dict[str, str]]:
+    package = importlib.import_module("treemendous")
+    native = importlib.import_module("treemendous.cpp._exact_batch")
+    requested = root.resolve()
+    package_file = package.__file__
+    native_file = native.__file__
+    if package_file is None or native_file is None:
+        raise AssertionError("worker imports must resolve to concrete files")
+    package_path = Path(package_file).resolve()
+    native_path = Path(native_file).resolve()
+    if not _is_descendant(package_path, requested):
+        raise AssertionError(
+            f"treemendous imported outside requested root {requested}: {package_path}"
+        )
+    if not _is_descendant(native_path, requested):
+        raise AssertionError(
+            f"native exact-batch module imported outside requested root {requested}: {native_path}"
+        )
+    return {
+        "treemendous": _file_metadata(package_path),
+        "native": _file_metadata(native_path),
+    }
+
+
+def _peak_rss_bytes() -> int:
+    import resource
+
+    value = int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
+    return value if sys.platform == "darwin" else value * 1024
+
+
+def _geometry(snapshot: Any) -> list[list[int]]:
+    return [[item.start, item.end] for item in snapshot.intervals]
+
+
+def _serialize_results(results: tuple[Any, ...]) -> list[dict[str, Any]]:
+    return [
+        {
+            "changed": [[span.start, span.end] for span in result.changed],
+            "changed_length": result.changed_length,
+            "fully_covered": result.fully_covered,
+        }
+        for result in results
+    ]
+
+
+def _worker_case(definition: dict[str, Any], root: Path) -> dict[str, Any]:
+    Span, create_range_set, BatchLimits, ExactBatchRangeSet, MutationOpcode = (
+        _worker_imports(root)
+    )
+    limits = BatchLimits(**RESOURCE_LIMITS)
+    domain = definition["domain"]
+    setup = definition["setup"]
+    rows = definition["rows"]
+
+    def new_exact() -> Any:
+        manager = ExactBatchRangeSet(
+            domain, initially_available=definition["initially_available"], limits=limits
+        )
+        if setup:
+            manager.mutate_packed(_packed(setup)).materialize()
+        return manager
+
+    def apply_scalar(
+        manager: Any, operations: tuple[Operation, ...]
+    ) -> tuple[Any, ...]:
+        output = []
+        for opcode, start, end in operations:
+            span = Span(start, end)
+            if opcode == MutationOpcode.ADD:
+                output.append(manager.add(span))
+            else:
+                output.append(
+                    manager.discard(
+                        span,
+                        require_covered=opcode
+                        == MutationOpcode.DISCARD_REQUIRE_COVERED,
+                    )
+                )
+        return tuple(output)
+
+    scalar = create_range_set(
+        domain,
+        backend="cpp_boundary",
+        initially_available=definition["initially_available"],
+    )
+    if setup:
+        apply_scalar(scalar, setup)
+    initial_geometry = _geometry(scalar.snapshot())
+    expected = apply_scalar(scalar, rows)
+    expected_final = _geometry(scalar.snapshot())
+    work_units = 0
+    work_scalar = create_range_set(
+        domain,
+        backend="cpp_boundary",
+        initially_available=definition["initially_available"],
+    )
+    if setup:
+        apply_scalar(work_scalar, setup)
+    for row in rows:
+        work_units += 1 + len(work_scalar.snapshot().intervals)
+        apply_scalar(work_scalar, (row,))
+
+    layer = definition.get("layer", "mutate")
+    iterations = definition.get("iterations", 1)
+    exact = new_exact()
+    packed_rows = _packed(rows)
+    result = None
+    observed_snapshot = None
+    materialized = None
+    if layer == "construction":
+        started = time.perf_counter_ns()
+        for _ in range(iterations):
+            exact = new_exact()
+        elapsed = time.perf_counter_ns() - started
+        observed_snapshot = exact.snapshot()
+    elif layer == "mutate":
+        started = time.perf_counter_ns()
+        for _ in range(iterations):
+            result = exact.mutate_packed(packed_rows)
+        elapsed = time.perf_counter_ns() - started
+        if result is None:
+            raise AssertionError("timed mutation produced no result")
+        materialized = result.materialize()
+        observed_snapshot = exact.snapshot()
+    elif layer == "snapshot":
+        started = time.perf_counter_ns()
+        for _ in range(iterations):
+            observed_snapshot = exact.snapshot()
+        elapsed = time.perf_counter_ns() - started
+    elif layer == "materialization":
+        result = exact.mutate_packed(packed_rows)
+        started = time.perf_counter_ns()
+        for _ in range(iterations):
+            materialized = result.materialize()
+        elapsed = time.perf_counter_ns() - started
+        observed_snapshot = exact.snapshot()
+    else:
+        raise AssertionError(f"unknown layer {layer}")
+
+    if observed_snapshot is None or _geometry(observed_snapshot) != expected_final:
+        raise AssertionError(
+            f"{definition['case_id']}: timed final snapshot differs from oracle"
+        )
+    if layer in ("mutate", "materialization") and materialized != expected:
+        raise AssertionError(
+            f"{definition['case_id']}: timed result differs from oracle"
+        )
+    if expected_final != initial_geometry:
+        raise AssertionError(f"{definition['case_id']}: workload is not restorative")
+    native = exact._manager
+    counters = (
+        native._storage_counters() if hasattr(native, "_storage_counters") else None
+    )
+    if counters is not None and (
+        set(counters) != set(COUNTER_KEYS)
+        or any(type(value) is not int for value in counters.values())
+    ):
+        raise AssertionError("candidate counter schema changed")
+    return {
+        "case_id": definition["case_id"],
+        "layer": layer,
+        "interval_count": definition["interval_count"],
+        "batch_size": len(rows),
+        "iterations": iterations,
+        "elapsed_ns": elapsed,
+        "ns_per_iteration": elapsed / iterations,
+        "oracle_digest": _checksum(
+            {"results": _serialize_results(expected), "final": expected_final}
+        ),
+        "legacy_work_units": work_units,
+        "counters": counters,
+        "peak_rss_bytes": _peak_rss_bytes(),
+    }
+
+
+def _binary_metadata(root: Path) -> dict[str, str]:
+    binaries = sorted((root / "treemendous/cpp").glob("_exact_batch*.so"))
+    if len(binaries) != 1:
+        raise ValueError(
+            f"expected one exact-batch binary under {root}, found {len(binaries)}"
+        )
+    path = binaries[0].resolve()
+    return {"path": str(path), "sha256": hashlib.sha256(path.read_bytes()).hexdigest()}
+
+
+def _worker_report(root: Path, mode: str, profile: str) -> dict[str, Any]:
+    root = root.resolve()
+    _purge_checkout_imports(root)
+    _worker_imports(root)
+    imports = _import_metadata(root)
+    definitions = (
+        diagnostic_definitions(profile)
+        if mode == "diagnostic"
+        else promotion_definitions(profile)
+    )
+    cells = [_worker_case(definition, root) for definition in definitions]
+    retained = None
+    if mode == "diagnostic" and profile == "full" and cells[0]["counters"] is not None:
+        definition = next(
+            item
+            for item in promotion_definitions()
+            if item["case_id"] == "promotion-local-n100000-b16"
+        )
+        _, _, BatchLimits, ExactBatchRangeSet, _ = _worker_imports(root)
+        manager = ExactBatchRangeSet(
+            definition["domain"],
+            initially_available=True,
+            limits=BatchLimits(**RESOURCE_LIMITS),
+        )
+        packed_rows = _packed(definition["rows"])
+        manager.mutate_packed(packed_rows)
+        warm = manager._manager._storage_counters()["retained_estimated_bytes"]
+        for _ in range(1_000):
+            manager.mutate_packed(packed_rows)
+        final = manager._manager._storage_counters()["retained_estimated_bytes"]
+        retained = {
+            "post_warmup_bytes": warm,
+            "after_1000_batches_bytes": final,
+            "ratio": final / warm,
+        }
+    return {
+        "schema": WORKER_SCHEMA,
+        "mode": mode,
+        "profile": profile,
+        "root": str(root),
+        "imports": imports,
+        "binary": imports["native"],
+        "cells": cells,
+        "retained_memory": retained,
+        "process_peak_rss_bytes": _peak_rss_bytes(),
+    }
+
+
+def _assert_distinct_binaries(
+    first: dict[str, str], second: dict[str, str], first_label: str, second_label: str
+) -> None:
+    if Path(first["path"]).resolve() == Path(second["path"]).resolve():
+        raise ValueError(
+            f"{first_label}/{second_label} resolved to the same native binary path: {first['path']}"
+        )
+    if first["sha256"] == second["sha256"]:
+        raise ValueError(
+            f"{first_label}/{second_label} resolved to the same native binary SHA-256: {first['sha256']}"
+        )
+
+
+def _validate_worker_report(
+    report: dict[str, Any], root: Path, comparison_root: Path | None = None
+) -> dict[str, Any]:
+    requested = root.resolve()
+    if Path(report.get("root", "")).resolve() != requested:
+        raise ValueError(
+            f"worker root mismatch: requested {requested}, reported {report.get('root')}"
+        )
+    imports = report.get("imports")
+    if type(imports) is not dict or set(imports) != {"treemendous", "native"}:
+        raise ValueError("worker import metadata schema mismatch")
+    for label in ("treemendous", "native"):
+        metadata = imports[label]
+        if type(metadata) is not dict or set(metadata) != {"path", "sha256"}:
+            raise ValueError(f"worker {label} import metadata schema mismatch")
+        path = Path(metadata["path"]).resolve()
+        if not _is_descendant(path, requested):
+            raise ValueError(
+                f"worker {label} import is outside requested root {requested}: {path}"
+            )
+        if _file_metadata(path) != metadata:
+            raise ValueError(f"worker {label} import path/hash mismatch")
+    if report.get("binary") != imports["native"]:
+        raise ValueError("worker binary metadata does not match imported native module")
+    if report["binary"] != _binary_metadata(requested):
+        raise ValueError(
+            "worker imported native module does not match requested-root binary"
+        )
+    if comparison_root is not None:
+        _assert_distinct_binaries(
+            report["binary"],
+            _binary_metadata(comparison_root.resolve()),
+            str(requested),
+            str(comparison_root.resolve()),
+        )
+    return report
+
+
+def _run_worker(
+    root: Path,
+    mode: str,
+    profile: str,
+    *,
+    comparison_root: Path | None = None,
+) -> dict[str, Any]:
+    root = root.resolve()
+    environment = os.environ.copy()
+    for name in ("PYTHONPATH", "PYTHONHOME", "PYTHONSTARTUP", "PYTHONUSERBASE"):
+        environment.pop(name, None)
+    environment["PYTHONNOUSERSITE"] = "1"
+    script = Path(__file__).resolve()
+    bootstrap = (
+        "import runpy,sys; "
+        "root,script=sys.argv[1:3]; args=sys.argv[3:]; "
+        "sys.path.insert(0,root); sys.argv=[script,*args]; "
+        "runpy.run_path(script,run_name='__main__')"
+    )
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-I",
+            "-S",
+            "-c",
+            bootstrap,
+            str(root),
+            str(script),
+            "--worker",
+            "--root",
+            str(root),
+            "--mode",
+            mode,
+            "--profile",
+            profile,
+        ],
+        cwd=root,
+        env=environment,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    report = json.loads(
+        completed.stdout,
+        object_pairs_hook=_reject_duplicate_keys,
+        parse_constant=_reject_non_finite,
+    )
+    return _validate_worker_report(report, root, comparison_root)
+
+
+def _git(root: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=root, check=True, capture_output=True, text=True
+    ).stdout
+
+
+def _source_provenance(root: Path) -> dict[str, Any]:
+    status = _git(root, "status", "--porcelain=v1")
+    diff = _git(root, "diff", "--binary", "HEAD")
+    changed = sorted(
+        line
+        for line in _git(
+            root, "ls-files", "--modified", "--others", "--exclude-standard"
+        ).splitlines()
+        if line
+    )
+    digest = hashlib.sha256((status + diff).encode())
+    for relative in changed:
+        path = root / relative
+        digest.update(relative.encode() + b"\0")
+        if path.is_file():
+            digest.update(hashlib.sha256(path.read_bytes()).digest())
+    return {
+        "root": str(root.resolve()),
+        "commit": _git(root, "rev-parse", "HEAD").strip(),
+        "tree": _git(root, "rev-parse", "HEAD^{tree}").strip(),
+        "clean": not status,
+        "changed_paths": changed,
+        "source_state_sha256": digest.hexdigest(),
+        "exact_batch_source_sha256": hashlib.sha256(
+            (root / "treemendous/cpp/exact_batch_bindings.cpp").read_bytes()
+        ).hexdigest(),
+        "binary": _binary_metadata(root),
+    }
+
+
+def _provenance(baseline: Path, candidate: Path) -> dict[str, Any]:
+    baseline_binary = _binary_metadata(baseline)
+    candidate_binary = _binary_metadata(candidate)
+    _assert_distinct_binaries(
+        baseline_binary, candidate_binary, "baseline", "candidate"
+    )
+    compiler = os.environ.get("CXX", "c++")
+    try:
+        compiler_version = subprocess.run(
+            [compiler, "--version"], check=True, capture_output=True, text=True
+        ).stdout.splitlines()[0]
+    except (OSError, subprocess.CalledProcessError):
+        compiler_version = "unavailable"
+    return {
+        "baseline": _source_provenance(baseline),
+        "candidate": _source_provenance(candidate),
+        "runtime": {
+            "python": platform.python_version(),
+            "implementation": platform.python_implementation(),
+            "python_compiler": platform.python_compiler(),
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "architecture": platform.architecture()[0],
+            "cpu_count": os.cpu_count() or 0,
+        },
+        "build": {
+            "command": "python setup.py build_ext --inplace --force",
+            "cxx": compiler,
+            "cxx_version": compiler_version,
+            "cc": str(sysconfig.get_config_var("CC") or "unknown"),
+            "cflags": str(sysconfig.get_config_var("CFLAGS") or "unknown"),
+        },
+    }
+
+
+def _promotion_rows(blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    case_ids = [cell["case_id"] for cell in blocks[0]["baseline"]["cells"]]
+    output = []
+    for case_id in case_ids:
+        raw = []
+        oracle = None
+        work_units = None
+        candidate_counters = []
+        layer = ""
+        count = 0
+        for block in blocks:
+            baseline = next(
+                cell
+                for cell in block["baseline"]["cells"]
+                if cell["case_id"] == case_id
+            )
+            candidate = next(
+                cell
+                for cell in block["candidate"]["cells"]
+                if cell["case_id"] == case_id
+            )
+            if (
+                baseline["oracle_digest"] != candidate["oracle_digest"]
+                or baseline["legacy_work_units"] != candidate["legacy_work_units"]
+            ):
+                raise AssertionError(
+                    f"{case_id}: baseline/candidate oracle or legacy work differs"
+                )
+            oracle = baseline["oracle_digest"]
+            work_units = baseline["legacy_work_units"]
+            layer = baseline["layer"]
+            count = baseline["interval_count"]
+            raw.append(candidate["ns_per_iteration"] / baseline["ns_per_iteration"])
+            if candidate["counters"] is not None:
+                candidate_counters.append(candidate["counters"])
+        output.append(
+            {
+                "case_id": case_id,
+                "layer": layer,
+                "interval_count": count,
+                "oracle_digest": oracle,
+                "legacy_work_units": work_units,
+                "candidate_counters_by_block": candidate_counters,
+                **_ratio_summary(raw),
+            }
+        )
+    return output
+
+
+def _gate(
+    name: str, observed: float, threshold: float, comparison: str
+) -> dict[str, Any]:
+    passed = observed <= threshold if comparison == "<=" else observed < threshold
+    return {
+        "name": name,
+        "observed": observed,
+        "threshold": threshold,
+        "comparison": comparison,
+        "passed": passed,
+    }
+
+
+def _gates(
+    rows: list[dict[str, Any]], diagnostic: dict[str, Any]
+) -> list[dict[str, Any]]:
+    by_id = {row["case_id"]: row for row in rows}
+    gates = [
+        _gate(
+            "n64_upper95",
+            by_id["promotion-restorative-n64-b16"][
+                "candidate_over_vector_confidence_95"
+            ][1],
+            1.10,
+            "<=",
+        ),
+        _gate(
+            "n100000_local_median",
+            by_id["promotion-local-n100000-b16"]["candidate_over_vector_median"],
+            0.50,
+            "<=",
+        ),
+        _gate(
+            "n100000_local_upper95",
+            by_id["promotion-local-n100000-b16"]["candidate_over_vector_confidence_95"][
+                1
+            ],
+            0.60,
+            "<",
+        ),
+    ]
+    for percentage in (1, 10, 100):
+        row = by_id[f"promotion-wide-n100000-p{percentage}"]
+        gates.append(
+            _gate(
+                f"wide_{percentage}_upper95",
+                row["candidate_over_vector_confidence_95"][1],
+                1.15,
+                "<=",
+            )
+        )
+    for count in INTERVAL_COUNTS:
+        row = by_id[f"promotion-snapshot-n{count}"]
+        gates.append(
+            _gate(
+                f"snapshot_n{count}_upper95",
+                row["candidate_over_vector_confidence_95"][1],
+                1.15,
+                "<=",
+            )
+        )
+    counters = {cell["case_id"]: cell["counters"] for cell in diagnostic["cells"]}
+    local_values = [
+        counters[f"matrix-n{count}-b16-middle"]["intervals_copied"]
+        for count in INTERVAL_COUNTS
+    ]
+    gates.append(
+        _gate(
+            "local_intervals_copied_bound", float(max(local_values)), float(8 * K), "<="
+        )
+    )
+    gates.append(
+        _gate(
+            "local_copy_n_growth",
+            float(max(local_values) - min(local_values)),
+            float(K),
+            "<=",
+        )
+    )
+    retained = diagnostic["retained_memory"]
+    gates.append(_gate("retained_bytes_after_1000", retained["ratio"], 1.10, "<="))
+    return gates
+
+
+def run_experiment(
+    *,
+    baseline_root: Path = DEFAULT_BASELINE,
+    candidate_root: Path = _REPOSITORY_ROOT,
+    blocks: int = PROMOTION_BLOCKS,
+    profile: str = "full",
+) -> dict[str, Any]:
+    if profile == "full" and blocks < PROMOTION_BLOCKS:
+        raise ValueError(
+            f"full evidence requires at least {PROMOTION_BLOCKS} fixed blocks"
+        )
+    if profile == "smoke" and blocks < 2:
+        raise ValueError("smoke evidence requires at least two blocks")
+    baseline_root = baseline_root.resolve()
+    candidate_root = candidate_root.resolve()
+    baseline_commit = _git(baseline_root, "rev-parse", "HEAD").strip()
+    if not baseline_commit.startswith(BASELINE_COMMIT):
+        raise ValueError(
+            f"baseline must be commit {BASELINE_COMMIT}, got {baseline_commit}"
+        )
+    diagnostic = _run_worker(
+        candidate_root,
+        "diagnostic",
+        profile,
+        comparison_root=baseline_root,
+    )
+    raw_blocks = []
+    for index in range(blocks):
+        order = (
+            ("baseline", "candidate") if index % 2 == 0 else ("candidate", "baseline")
+        )
+        measured = {
+            name: _run_worker(
+                baseline_root if name == "baseline" else candidate_root,
+                "promotion",
+                profile,
+                comparison_root=(
+                    candidate_root if name == "baseline" else baseline_root
+                ),
+            )
+            for name in order
+        }
+        raw_blocks.append(
+            {
+                "block_index": index,
+                "process_order": list(order),
+                "baseline": measured["baseline"],
+                "candidate": measured["candidate"],
+            }
+        )
+    rows = _promotion_rows(raw_blocks)
+    gates = _gates(rows, diagnostic) if profile == "full" else []
+    return {
+        "schema": SCHEMA,
+        "profile": profile,
+        "decision": "ACCEPTED"
+        if gates and all(gate["passed"] for gate in gates)
+        else ("REJECTED" if gates else "DIAGNOSTIC"),
+        "provenance": _provenance(baseline_root, candidate_root),
+        "methodology": {
+            "fixed_balanced_blocks": blocks,
+            "process_order": "baseline-first on even blocks; candidate-first on odd blocks",
+            "worker_scope": "one isolated process measures the complete matrix for one root and block",
+            "timed_instance": "restorative calls reuse one instance; last packed result and final snapshot are validated outside timing",
+            "excluded": "manager/workload setup except construction cells, canonical scalar replay, packed-result validation, final snapshots, counters, RSS, and artifact writing",
+            "bootstrap_unit": "whole balanced block candidate/vector ratio",
+            "bootstrap_resamples": BOOTSTRAP_RESAMPLES,
+            "bootstrap_seed": BOOTSTRAP_SEED,
+        },
+        "resource_limits": dict(RESOURCE_LIMITS),
+        "matrix_identity": {
+            "interval_counts": list(INTERVAL_COUNTS if profile == "full" else (64,)),
+            "batch_sizes": list(BATCH_SIZES if profile == "full" else (0, 16)),
+            "diagnostic_shapes": list(DIAGNOSTIC_SHAPES),
+            "block_counts": list(BLOCK_COUNTS),
+            "block_shapes": list(BLOCK_SHAPES),
+            "promotion_case_ids": [
+                item["case_id"] for item in promotion_definitions(profile)
+            ],
+        },
+        "diagnostic_candidate": diagnostic,
+        "balanced_blocks": raw_blocks,
+        "promotion_rows": rows,
+        "gates": gates,
+    }
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    output: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in output:
+            raise ValueError(f"duplicate key: {key}")
+        output[key] = value
+    return output
+
+
+def _reject_non_finite(value: str) -> None:
+    raise ValueError(f"non-finite number: {value}")
+
+
+def _validate_types(value: Any) -> None:
+    if type(value) not in (dict, list, str, int, float, bool, type(None)):
+        raise ValueError("artifact contains an unsupported JSON type")
+    if type(value) is float and not math.isfinite(value):
+        raise ValueError("artifact contains a non-finite number")
+    if type(value) is dict:
+        for key, item in value.items():
+            if type(key) is not str:
+                raise ValueError("artifact object key is not a string")
+            _validate_types(item)
+    elif type(value) is list:
+        for item in value:
+            _validate_types(item)
+
+
+def _exact_keys(value: Any, keys: set[str], label: str) -> dict[str, Any]:
+    if type(value) is not dict or set(value) != keys:
+        raise ValueError(f"{label} schema mismatch")
+    return value
+
+
+def _json_exact(actual: Any, expected: Any) -> bool:
+    if type(actual) is not type(expected):
+        return False
+    if type(actual) is dict:
+        return actual.keys() == expected.keys() and all(
+            _json_exact(actual[key], expected[key]) for key in actual
+        )
+    if type(actual) is list:
+        return len(actual) == len(expected) and all(
+            _json_exact(left, right)
+            for left, right in zip(actual, expected, strict=True)
+        )
+    return bool(actual == expected)
+
+
+def _archived_rejection(report: dict[str, Any]) -> dict[str, Any]:
+    row = next(
+        item
+        for item in report["promotion_rows"]
+        if item["case_id"] == "promotion-restorative-n64-b16"
+    )
+    upper = row["candidate_over_vector_confidence_95"][1]
+    return {
+        "decision": "REJECTED" if upper > 1.10 else "ACCEPTED",
+        "workload": row["case_id"],
+        "balanced_blocks": len(report["balanced_blocks"]),
+        "candidate_over_vector_median": row["candidate_over_vector_median"],
+        "candidate_over_vector_confidence_95": row[
+            "candidate_over_vector_confidence_95"
+        ],
+        "upper95_gate": 1.10,
+    }
+
+
+def archive_metadata(report: dict[str, Any]) -> dict[str, Any]:
+    """Bind the durable rejection archive to its reproducible source patch."""
+    return {
+        "source_artifact": ARCHIVE_SOURCE_ARTIFACT,
+        "patch": {
+            "path": str(SEGMENTED_PATCH),
+            "sha256": SEGMENTED_PATCH_SHA256,
+        },
+        "baseline": {
+            "commit": BASELINE_FULL_COMMIT,
+            "exact_batch_source_sha256": BASELINE_SOURCE_SHA256,
+            "binary_sha256": BASELINE_BINARY_SHA256,
+        },
+        "candidate": {
+            "result_exact_batch_source_sha256": SEGMENTED_SOURCE_SHA256,
+            "binary_sha256": SEGMENTED_BINARY_SHA256,
+        },
+        "runtime": dict(ARCHIVED_RUNTIME),
+        "rejection": _archived_rejection(report),
+    }
+
+
+def _verify_patch_application() -> None:
+    patch = (_REPOSITORY_ROOT / SEGMENTED_PATCH).read_bytes()
+    if hashlib.sha256(patch).hexdigest() != SEGMENTED_PATCH_SHA256:
+        raise ValueError("segmented patch checksum mismatch")
+    source = subprocess.run(
+        [
+            "git",
+            "show",
+            f"{BASELINE_FULL_COMMIT}:treemendous/cpp/exact_batch_bindings.cpp",
+        ],
+        cwd=_REPOSITORY_ROOT,
+        check=True,
+        capture_output=True,
+    ).stdout
+    if hashlib.sha256(source).hexdigest() != BASELINE_SOURCE_SHA256:
+        raise ValueError("baseline exact-batch source checksum mismatch")
+    with tempfile.TemporaryDirectory(prefix="treemendous-segmented-proof-") as raw:
+        root = Path(raw)
+        destination = root / "treemendous/cpp/exact_batch_bindings.cpp"
+        destination.parent.mkdir(parents=True)
+        destination.write_bytes(source)
+        completed = subprocess.run(
+            ["patch", "-p1", "--batch", "--forward"],
+            cwd=root,
+            input=patch,
+            capture_output=True,
+        )
+        if completed.returncode != 0:
+            raise ValueError("segmented patch does not apply to baseline source")
+        if (
+            hashlib.sha256(destination.read_bytes()).hexdigest()
+            != SEGMENTED_SOURCE_SHA256
+        ):
+            raise ValueError("segmented patch result checksum mismatch")
+
+
+def _offline_cell_expected(definition: dict[str, Any]) -> tuple[str, int]:
+    """Reconstruct oracle and work declarations without segmented runtime hooks."""
+    from treemendous import Span, create_range_set
+
+    manager = create_range_set(
+        definition["domain"],
+        backend="py_boundary",
+        initially_available=definition["initially_available"],
+    )
+
+    def apply(operations: tuple[Operation, ...]) -> tuple[Any, ...]:
+        output = []
+        for opcode, start, end in operations:
+            span = Span(start, end)
+            if opcode == 0:
+                output.append(manager.add(span))
+            else:
+                output.append(manager.discard(span, require_covered=opcode == 2))
+        return tuple(output)
+
+    if definition["setup"]:
+        apply(definition["setup"])
+    work_units = 0
+    results: list[Any] = []
+    for operation in definition["rows"]:
+        work_units += 1 + len(manager.snapshot().intervals)
+        results.extend(apply((operation,)))
+    final = _geometry(manager.snapshot())
+    return (
+        _checksum({"results": _serialize_results(tuple(results)), "final": final}),
+        work_units,
+    )
+
+
+def _sha256_string(value: Any) -> bool:
+    return (
+        type(value) is str
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _verify_archived_worker(
+    report: Any,
+    *,
+    root_role: str,
+    mode: str,
+    definitions: tuple[dict[str, Any], ...],
+) -> None:
+    worker = _exact_keys(
+        report,
+        {
+            "schema",
+            "mode",
+            "profile",
+            "root",
+            "imports",
+            "binary",
+            "cells",
+            "retained_memory",
+            "process_peak_rss_bytes",
+        },
+        "archived worker",
+    )
+    if (
+        worker["schema"] != WORKER_SCHEMA
+        or worker["mode"] != mode
+        or worker["profile"] != "smoke"
+        or type(worker["root"]) is not str
+        or not Path(worker["root"]).is_absolute()
+        or worker["retained_memory"] is not None
+        or type(worker["process_peak_rss_bytes"]) is not int
+        or worker["process_peak_rss_bytes"] <= 0
+    ):
+        raise ValueError("archived worker identity/profile mismatch")
+    imports = _exact_keys(
+        worker["imports"], {"treemendous", "native"}, "archived imports"
+    )
+    for label in ("treemendous", "native"):
+        metadata = _exact_keys(
+            imports[label], {"path", "sha256"}, f"archived {label} import"
+        )
+        if (
+            type(metadata["path"]) is not str
+            or not Path(metadata["path"]).is_absolute()
+            or not Path(metadata["path"]).is_relative_to(Path(worker["root"]))
+            or not _sha256_string(metadata["sha256"])
+        ):
+            raise ValueError("archived import path/hash mismatch")
+    if worker["binary"] != imports["native"]:
+        raise ValueError("archived binary/import mismatch")
+    expected_binary = (
+        BASELINE_BINARY_SHA256 if root_role == "baseline" else SEGMENTED_BINARY_SHA256
+    )
+    expected_root = (
+        ARCHIVED_BASELINE_ROOT if root_role == "baseline" else ARCHIVED_CANDIDATE_ROOT
+    )
+    if (
+        worker["root"] != expected_root
+        or worker["binary"]["sha256"] != expected_binary
+        or imports["treemendous"]["sha256"] != ARCHIVED_PACKAGE_SHA256
+    ):
+        raise ValueError("archived root/import/binary provenance mismatch")
+
+    cells = worker["cells"]
+    if type(cells) is not list or len(cells) != len(definitions):
+        raise ValueError("archived worker matrix length mismatch")
+    cell_keys = {
+        "case_id",
+        "layer",
+        "interval_count",
+        "batch_size",
+        "iterations",
+        "elapsed_ns",
+        "ns_per_iteration",
+        "oracle_digest",
+        "legacy_work_units",
+        "counters",
+        "peak_rss_bytes",
+    }
+    observed_ids = []
+    for cell, definition in zip(cells, definitions, strict=True):
+        _exact_keys(cell, cell_keys, "archived worker cell")
+        if type(cell["case_id"]) is not str or cell["case_id"] != definition["case_id"]:
+            raise ValueError("archived worker matrix order/uniqueness mismatch")
+        observed_ids.append(cell["case_id"])
+        expected_oracle, expected_work = _offline_cell_expected(definition)
+        expected_layer = definition.get("layer", "mutate")
+        expected_iterations = definition.get("iterations", 1)
+        if (
+            type(cell["case_id"]) is not str
+            or cell["case_id"] != definition["case_id"]
+            or type(cell["layer"]) is not str
+            or cell["layer"] != expected_layer
+            or type(cell["interval_count"]) is not int
+            or cell["interval_count"] != definition["interval_count"]
+            or type(cell["batch_size"]) is not int
+            or cell["batch_size"] != len(definition["rows"])
+            or type(cell["iterations"]) is not int
+            or cell["iterations"] != expected_iterations
+            or type(cell["elapsed_ns"]) is not int
+            or cell["elapsed_ns"] <= 0
+            or type(cell["ns_per_iteration"]) is not float
+            or cell["ns_per_iteration"] != cell["elapsed_ns"] / expected_iterations
+            or type(cell["oracle_digest"]) is not str
+            or cell["oracle_digest"] != expected_oracle
+            or type(cell["legacy_work_units"]) is not int
+            or cell["legacy_work_units"] != expected_work
+            or type(cell["peak_rss_bytes"]) is not int
+            or cell["peak_rss_bytes"] <= 0
+        ):
+            raise ValueError("archived worker cell derivation mismatch")
+        counters = cell["counters"]
+        if root_role == "baseline":
+            if counters is not None:
+                raise ValueError("archived baseline unexpectedly exposes counters")
+        else:
+            _exact_keys(counters, set(COUNTER_KEYS), "archived candidate counters")
+            if any(type(value) is not int for value in counters.values()):
+                raise ValueError("archived candidate counter type mismatch")
+    expected_ids = [definition["case_id"] for definition in definitions]
+    if observed_ids != expected_ids or len(set(observed_ids)) != len(expected_ids):
+        raise ValueError("archived worker matrix order/uniqueness mismatch")
+
+
+def render_markdown(report: dict[str, Any], digest: str) -> str:
+    lines = [
+        "# Segmented ExactBatch storage qualification",
+        "",
+        f"- Decision: **{report['decision']}**",
+        f"- Balanced blocks: `{report['methodology']['fixed_balanced_blocks']}`",
+        f"- Baseline: `{report['provenance']['baseline']['commit']}`",
+        f"- JSON SHA-256: `{digest}`",
+        "",
+    ]
+    if "archive" in report:
+        archive = report["archive"]
+        lines.extend(
+            (
+                f"- Archived segmented decision: **{archive['rejection']['decision']}**",
+                f"- Segmented patch SHA-256: `{archive['patch']['sha256']}`",
+                f"- Resulting source SHA-256: `{archive['candidate']['result_exact_batch_source_sha256']}`",
+                "",
+            )
+        )
+    lines.extend(
+        [
+            "| Cell | Median candidate/vector | Upper 95% |",
+            "|---|---:|---:|",
+        ]
+    )
+    for row in report["promotion_rows"]:
+        lines.append(
+            f"| {row['case_id']} | {row['candidate_over_vector_median']:.4f} | {row['candidate_over_vector_confidence_95'][1]:.4f} |"
+        )
+    lines.extend(
+        ("", "| Gate | Observed | Threshold | Result |", "|---|---:|---:|---|")
+    )
+    for gate in report["gates"]:
+        lines.append(
+            f"| {gate['name']} | {gate['observed']:.6g} | {gate['comparison']} {gate['threshold']:.6g} | {'pass' if gate['passed'] else 'fail'} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_artifacts(report: dict[str, Any], output: Path) -> tuple[Path, Path, Path]:
+    if output.suffix != ".json":
+        raise ValueError("output must have .json suffix")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (json.dumps(report, indent=2, sort_keys=True) + "\n").encode()
+    digest = hashlib.sha256(encoded).hexdigest()
+    markdown = output.with_suffix(".md")
+    checksum = Path(f"{output}.sha256")
+    for path, content in (
+        (output, encoded),
+        (markdown, render_markdown(report, digest).encode()),
+        (checksum, f"{digest}  {output.name}\n".encode()),
+    ):
+        temporary = path.with_name(f".{path.name}.tmp")
+        temporary.write_bytes(content)
+        temporary.replace(path)
+    return output, markdown, checksum
+
+
+def verify_artifacts(output: Path) -> dict[str, Any]:
+    markdown = output.with_suffix(".md")
+    checksum = Path(f"{output}.sha256")
+    if not all(path.is_file() for path in (output, markdown, checksum)):
+        raise ValueError("artifact triplet is incomplete")
+    encoded = output.read_bytes()
+    digest = hashlib.sha256(encoded).hexdigest()
+    if checksum.read_text() != f"{digest}  {output.name}\n":
+        raise ValueError("checksum mismatch")
+    report = json.loads(
+        encoded,
+        object_pairs_hook=_reject_duplicate_keys,
+        parse_constant=_reject_non_finite,
+    )
+    _validate_types(report)
+    if encoded != (json.dumps(report, indent=2, sort_keys=True) + "\n").encode():
+        raise ValueError("JSON is not canonical")
+    _exact_keys(
+        report,
+        {
+            "schema",
+            "profile",
+            "decision",
+            "provenance",
+            "methodology",
+            "resource_limits",
+            "matrix_identity",
+            "diagnostic_candidate",
+            "balanced_blocks",
+            "promotion_rows",
+            "gates",
+        },
+        "report",
+    )
+    if report["schema"] != SCHEMA or report["profile"] not in ("full", "smoke"):
+        raise ValueError("schema/profile mismatch")
+    if report["resource_limits"] != RESOURCE_LIMITS:
+        raise ValueError("resource limits mismatch")
+    profile = report["profile"]
+    expected_identity = {
+        "interval_counts": list(INTERVAL_COUNTS if profile == "full" else (64,)),
+        "batch_sizes": list(BATCH_SIZES if profile == "full" else (0, 16)),
+        "diagnostic_shapes": list(DIAGNOSTIC_SHAPES),
+        "block_counts": list(BLOCK_COUNTS),
+        "block_shapes": list(BLOCK_SHAPES),
+        "promotion_case_ids": [
+            item["case_id"] for item in promotion_definitions(profile)
+        ],
+    }
+    if report["matrix_identity"] != expected_identity:
+        raise ValueError("matrix identity mismatch")
+    blocks = report["balanced_blocks"]
+    required = PROMOTION_BLOCKS if profile == "full" else 2
+    if type(blocks) is not list or len(blocks) < required:
+        raise ValueError("balanced block count is insufficient")
+    provenance = report["provenance"]
+    baseline = Path(provenance["baseline"]["root"])
+    candidate = Path(provenance["candidate"]["root"])
+    _validate_worker_report(report["diagnostic_candidate"], candidate, baseline)
+    for index, block in enumerate(blocks):
+        expected_order = (
+            ["baseline", "candidate"] if index % 2 == 0 else ["candidate", "baseline"]
+        )
+        if block["block_index"] != index or block["process_order"] != expected_order:
+            raise ValueError("balanced process order mismatch")
+        _validate_worker_report(block["baseline"], baseline, candidate)
+        _validate_worker_report(block["candidate"], candidate, baseline)
+    reconstructed_rows = _promotion_rows(blocks)
+    if report["promotion_rows"] != reconstructed_rows:
+        raise ValueError("promotion derivation mismatch")
+    if provenance != _provenance(baseline, candidate):
+        raise ValueError("source/runtime/compiler/binary provenance mismatch")
+    expected_gates = (
+        _gates(reconstructed_rows, report["diagnostic_candidate"])
+        if profile == "full"
+        else []
+    )
+    if report["gates"] != expected_gates:
+        raise ValueError("gate derivation mismatch")
+    expected_decision = (
+        "ACCEPTED"
+        if expected_gates and all(item["passed"] for item in expected_gates)
+        else ("REJECTED" if expected_gates else "DIAGNOSTIC")
+    )
+    if report["decision"] != expected_decision:
+        raise ValueError("decision mismatch")
+    if markdown.read_text() != render_markdown(report, digest):
+        raise ValueError("Markdown mismatch")
+    return report
+
+
+def verify_archive_artifacts(output: Path) -> dict[str, Any]:
+    """Verify the durable historical archive without loading its old binaries."""
+    markdown = output.with_suffix(".md")
+    checksum = Path(f"{output}.sha256")
+    if output.name != ARCHIVE_NAME:
+        raise ValueError("archive filename mismatch")
+    if not all(path.is_file() for path in (output, markdown, checksum)):
+        raise ValueError("archive triplet is incomplete")
+    encoded = output.read_bytes()
+    digest = hashlib.sha256(encoded).hexdigest()
+    if checksum.read_text() != f"{digest}  {output.name}\n":
+        raise ValueError("archive checksum mismatch")
+    report = json.loads(
+        encoded,
+        object_pairs_hook=_reject_duplicate_keys,
+        parse_constant=_reject_non_finite,
+    )
+    _validate_types(report)
+    if encoded != (json.dumps(report, indent=2, sort_keys=True) + "\n").encode():
+        raise ValueError("archive JSON is not canonical")
+    _exact_keys(
+        report,
+        {
+            "schema",
+            "profile",
+            "decision",
+            "provenance",
+            "methodology",
+            "resource_limits",
+            "matrix_identity",
+            "diagnostic_candidate",
+            "balanced_blocks",
+            "promotion_rows",
+            "gates",
+            "archive",
+        },
+        "archive report",
+    )
+    if (
+        report["schema"] != SCHEMA
+        or report["profile"] != "smoke"
+        or report["decision"] != "DIAGNOSTIC"
+        or report["gates"] != []
+        or not _json_exact(report["resource_limits"], RESOURCE_LIMITS)
+    ):
+        raise ValueError("archive report identity mismatch")
+    expected_methodology = {
+        "fixed_balanced_blocks": PROMOTION_BLOCKS,
+        "process_order": "baseline-first on even blocks; candidate-first on odd blocks",
+        "worker_scope": "one isolated process measures the complete matrix for one root and block",
+        "timed_instance": "restorative calls reuse one instance; last packed result and final snapshot are validated outside timing",
+        "excluded": "manager/workload setup except construction cells, canonical scalar replay, packed-result validation, final snapshots, counters, RSS, and artifact writing",
+        "bootstrap_unit": "whole balanced block candidate/vector ratio",
+        "bootstrap_resamples": BOOTSTRAP_RESAMPLES,
+        "bootstrap_seed": BOOTSTRAP_SEED,
+    }
+    if not _json_exact(report["methodology"], expected_methodology):
+        raise ValueError("archive methodology mismatch")
+    expected_identity = {
+        "interval_counts": [64],
+        "batch_sizes": [0, 16],
+        "diagnostic_shapes": list(DIAGNOSTIC_SHAPES),
+        "block_counts": list(BLOCK_COUNTS),
+        "block_shapes": list(BLOCK_SHAPES),
+        "promotion_case_ids": [
+            definition["case_id"] for definition in promotion_definitions("smoke")
+        ],
+    }
+    if not _json_exact(report["matrix_identity"], expected_identity):
+        raise ValueError("archive matrix identity mismatch")
+
+    provenance = _exact_keys(
+        report["provenance"],
+        {"baseline", "candidate", "runtime", "build"},
+        "archive provenance",
+    )
+    source_keys = {
+        "root",
+        "commit",
+        "tree",
+        "clean",
+        "changed_paths",
+        "source_state_sha256",
+        "exact_batch_source_sha256",
+        "binary",
+    }
+    for role in ("baseline", "candidate"):
+        source = _exact_keys(provenance[role], source_keys, f"archive {role}")
+        binary = _exact_keys(source["binary"], {"path", "sha256"}, "archive binary")
+        if (
+            type(source["root"]) is not str
+            or not Path(source["root"]).is_absolute()
+            or type(source["commit"]) is not str
+            or source["commit"] != BASELINE_FULL_COMMIT
+            or type(source["tree"]) is not str
+            or source["tree"] != ARCHIVED_TREE
+            or type(source["clean"]) is not bool
+            or type(source["changed_paths"]) is not list
+            or any(type(path) is not str for path in source["changed_paths"])
+            or source["changed_paths"] != sorted(set(source["changed_paths"]))
+            or not _sha256_string(source["source_state_sha256"])
+            or type(binary["path"]) is not str
+            or not Path(binary["path"]).is_absolute()
+            or not Path(binary["path"]).is_relative_to(Path(source["root"]))
+        ):
+            raise ValueError("archive source provenance type/path mismatch")
+    baseline_source = provenance["baseline"]
+    candidate_source = provenance["candidate"]
+    baseline_changed_digest = hashlib.sha256(
+        json.dumps(baseline_source["changed_paths"], separators=(",", ":")).encode()
+    ).hexdigest()
+    candidate_changed_digest = hashlib.sha256(
+        json.dumps(candidate_source["changed_paths"], separators=(",", ":")).encode()
+    ).hexdigest()
+    if (
+        baseline_source["root"] != ARCHIVED_BASELINE_ROOT
+        or candidate_source["root"] != ARCHIVED_CANDIDATE_ROOT
+        or baseline_source["clean"] is not True
+        or baseline_source["changed_paths"] != []
+        or baseline_changed_digest != ARCHIVED_BASELINE_CHANGED_PATHS_SHA256
+        or candidate_changed_digest != ARCHIVED_CANDIDATE_CHANGED_PATHS_SHA256
+        or baseline_source["source_state_sha256"] != ARCHIVED_BASELINE_STATE_SHA256
+        or candidate_source["source_state_sha256"] != ARCHIVED_CANDIDATE_STATE_SHA256
+        or baseline_source["exact_batch_source_sha256"] != BASELINE_SOURCE_SHA256
+        or baseline_source["binary"]["sha256"] != BASELINE_BINARY_SHA256
+        or candidate_source["clean"] is not False
+        or "treemendous/cpp/exact_batch_bindings.cpp"
+        not in candidate_source["changed_paths"]
+        or candidate_source["exact_batch_source_sha256"] != SEGMENTED_SOURCE_SHA256
+        or candidate_source["binary"]["sha256"] != SEGMENTED_BINARY_SHA256
+        or baseline_source["root"] == candidate_source["root"]
+        or baseline_source["binary"]["path"] == candidate_source["binary"]["path"]
+        or baseline_source["binary"]["sha256"] == candidate_source["binary"]["sha256"]
+    ):
+        raise ValueError("archive source/binary provenance mismatch")
+    if not _json_exact(provenance["runtime"], ARCHIVED_RUNTIME):
+        raise ValueError("archive runtime provenance mismatch")
+    build = _exact_keys(
+        provenance["build"],
+        {"command", "cxx", "cxx_version", "cc", "cflags"},
+        "archive build",
+    )
+    if not _json_exact(build, ARCHIVED_BUILD):
+        raise ValueError("archive build provenance mismatch")
+
+    promotion_definitions_smoke = promotion_definitions("smoke")
+    diagnostic_definitions_smoke = diagnostic_definitions("smoke")
+    diagnostic = report["diagnostic_candidate"]
+    _verify_archived_worker(
+        diagnostic,
+        root_role="candidate",
+        mode="diagnostic",
+        definitions=diagnostic_definitions_smoke,
+    )
+    if diagnostic["root"] != candidate_source["root"]:
+        raise ValueError("archive diagnostic candidate root mismatch")
+    blocks = report["balanced_blocks"]
+    if type(blocks) is not list or len(blocks) != PROMOTION_BLOCKS:
+        raise ValueError("archive exact balanced block count mismatch")
+    for index, block in enumerate(blocks):
+        _exact_keys(
+            block,
+            {"block_index", "process_order", "baseline", "candidate"},
+            "archive balanced block",
+        )
+        expected_order = (
+            ["baseline", "candidate"] if index % 2 == 0 else ["candidate", "baseline"]
+        )
+        if (
+            type(block["block_index"]) is not int
+            or block["block_index"] != index
+            or block["process_order"] != expected_order
+        ):
+            raise ValueError("archive balanced block ordering mismatch")
+        _verify_archived_worker(
+            block["baseline"],
+            root_role="baseline",
+            mode="promotion",
+            definitions=promotion_definitions_smoke,
+        )
+        _verify_archived_worker(
+            block["candidate"],
+            root_role="candidate",
+            mode="promotion",
+            definitions=promotion_definitions_smoke,
+        )
+        if (
+            block["baseline"]["root"] != baseline_source["root"]
+            or block["candidate"]["root"] != candidate_source["root"]
+        ):
+            raise ValueError("archive worker/root provenance mismatch")
+
+    reconstructed_rows = _promotion_rows(blocks)
+    if not _json_exact(report["promotion_rows"], reconstructed_rows):
+        raise ValueError("archive promotion raw derivation mismatch")
+    expected_row_ids = [item["case_id"] for item in promotion_definitions_smoke]
+    observed_row_ids = [item["case_id"] for item in report["promotion_rows"]]
+    if observed_row_ids != expected_row_ids or len(set(observed_row_ids)) != len(
+        expected_row_ids
+    ):
+        raise ValueError("archive promotion matrix order/uniqueness mismatch")
+    if not _json_exact(report["archive"], archive_metadata(report)):
+        raise ValueError("archive patch/rejection binding mismatch")
+    _verify_patch_application()
+    if markdown.read_text() != render_markdown(report, digest):
+        raise ValueError("archive Markdown mismatch")
+    return report
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline-root", type=Path, default=DEFAULT_BASELINE)
+    parser.add_argument("--candidate-root", type=Path, default=_REPOSITORY_ROOT)
+    parser.add_argument("--blocks", type=int, default=PROMOTION_BLOCKS)
+    parser.add_argument("--profile", choices=("full", "smoke"), default="full")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("build/experiments/exact-batch-storage-matrix.json"),
+    )
+    parser.add_argument("--verify", action="store_true")
+    parser.add_argument(
+        "--archive",
+        action="store_true",
+        help="verify the durable historical rejection without old checkout binaries",
+    )
+    parser.add_argument("--worker", action="store_true", help=argparse.SUPPRESS)
+    parser.add_argument("--root", type=Path, help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--mode", choices=("diagnostic", "promotion"), help=argparse.SUPPRESS
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    if args.worker:
+        if args.root is None or args.mode is None:
+            raise SystemExit("worker requires --root and --mode")
+        print(
+            json.dumps(
+                _worker_report(args.root.resolve(), args.mode, args.profile),
+                separators=(",", ":"),
+                sort_keys=True,
+            )
+        )
+        return 0
+    if args.archive:
+        if not args.verify:
+            raise SystemExit("--archive requires --verify")
+        report = verify_archive_artifacts(args.output)
+    elif args.verify:
+        report = verify_artifacts(args.output)
+    else:
+        report = run_experiment(
+            baseline_root=args.baseline_root,
+            candidate_root=args.candidate_root,
+            blocks=args.blocks,
+            profile=args.profile,
+        )
+        write_artifacts(report, args.output)
+        verify_artifacts(args.output)
+    print(
+        f"decision={report['decision']} blocks={len(report['balanced_blocks'])} output={args.output}"
+    )
+    return int(report["decision"] == "REJECTED")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/performance/experiments/fixtures/exact_batch_segmented_tuned.patch
+++ b/tests/performance/experiments/fixtures/exact_batch_segmented_tuned.patch
@@ -1,0 +1,527 @@
+--- a/treemendous/cpp/exact_batch_bindings.cpp
++++ b/treemendous/cpp/exact_batch_bindings.cpp
+@@ -5,6 +5,7 @@
+ 
+ #include <algorithm>
+ #include <atomic>
++#include <condition_variable>
+ #include <cstdint>
+ #include <cstring>
+ #include <limits>
+@@ -338,8 +339,81 @@
+     std::size_t changed_spans;
+     std::size_t result_bytes;
+     std::size_t work_units;
++};
++
++constexpr std::size_t kTargetBlockIntervals = 128;
++
++struct IntervalBlock {
++    explicit IntervalBlock(std::vector<Interval>& values) {
++        intervals.swap(values);
++        first_start = intervals.front().first;
++        last_end = intervals.back().second;
++    }
++
++    std::vector<Interval> intervals;
++    Coordinate first_start = 0;
++    Coordinate last_end = 0;
+ };
+ 
++using BlockPtr = std::shared_ptr<const IntervalBlock>;
++
++struct StorageCounters {
++    std::size_t directory_entries_copied = 0;
++    std::size_t blocks_rebuilt = 0;
++    std::size_t intervals_copied = 0;
++    std::int64_t block_delta = 0;
++    std::uint64_t generation = 0;
++    std::size_t live_count = 0;
++    std::size_t block_count = 0;
++    std::size_t transient_estimated_bytes = 0;
++    std::size_t retained_estimated_bytes = 0;
++};
++
++struct State {
++    State(std::vector<BlockPtr>& directory_value, std::size_t live_count_value,
++          Coordinate total_value, const StorageCounters& counters_value)
++        : live_count(live_count_value), total(total_value),
++          counters(counters_value) {
++        directory.swap(directory_value);
++    }
++
++    std::vector<BlockPtr> directory;
++    std::size_t live_count;
++    Coordinate total;
++    StorageCounters counters;
++};
++
++using StatePtr = std::shared_ptr<const State>;
++
++void estimated_byte_add(std::size_t& value, std::size_t amount) noexcept {
++    if (amount > std::numeric_limits<std::size_t>::max() - value) {
++        value = std::numeric_limits<std::size_t>::max();
++    } else {
++        value += amount;
++    }
++}
++
++void estimated_array_add(std::size_t& value, std::size_t count,
++                         std::size_t item_size) noexcept {
++    if (count != 0 &&
++        item_size > std::numeric_limits<std::size_t>::max() / count) {
++        value = std::numeric_limits<std::size_t>::max();
++        return;
++    }
++    estimated_byte_add(value, count * item_size);
++}
++
++std::size_t retained_storage_bytes(
++    const std::vector<BlockPtr>& directory) noexcept {
++    std::size_t result = sizeof(State);
++    estimated_array_add(result, directory.size(), sizeof(BlockPtr));
++    for (const auto& block : directory) {
++        estimated_byte_add(result, sizeof(IntervalBlock));
++        estimated_array_add(result, block->intervals.size(), sizeof(Interval));
++    }
++    return result;
++}
++
+ class ExactBatchManager {
+   public:
+     ExactBatchManager(const std::vector<Interval>& domain, bool initially_available,
+@@ -349,7 +423,6 @@
+                       std::size_t max_result_bytes,
+                       std::size_t max_work_units)
+         : domain_(domain),
+-          state_(initially_available ? domain_ : std::vector<Interval>{}),
+           limits_{max_operations, max_live_intervals, max_changed_spans,
+                   max_result_bytes, max_work_units} {
+         validate_limit(max_operations, "max_operations");
+@@ -357,8 +430,6 @@
+         validate_limit(max_changed_spans, "max_changed_spans");
+         validate_limit(max_result_bytes, "max_result_bytes");
+         validate_limit(max_work_units, "max_work_units");
+-        if (state_.size() > limits_.live_intervals)
+-            limit_error("max_live_intervals");
+ 
+         Coordinate total = 0;
+         Coordinate previous_end = 0;
+@@ -376,7 +447,26 @@
+             first = false;
+         }
+         if (domain_.empty()) throw py::value_error("managed domain must not be empty");
+-        total_ = initially_available ? total : 0;
++
++        std::vector<Interval> initial =
++            initially_available ? domain_ : std::vector<Interval>{};
++        if (initial.size() > limits_.live_intervals)
++            limit_error("max_live_intervals");
++        std::vector<BlockPtr> directory;
++        for (std::size_t begin = 0; begin < initial.size();
++             begin += kTargetBlockIntervals) {
++            const std::size_t end =
++                std::min(initial.size(), begin + kTargetBlockIntervals);
++            std::vector<Interval> chunk(initial.begin() + begin,
++                                        initial.begin() + end);
++            directory.push_back(std::make_shared<IntervalBlock>(chunk));
++        }
++        StorageCounters counters;
++        counters.live_count = initial.size();
++        counters.block_count = directory.size();
++        counters.retained_estimated_bytes = retained_storage_bytes(directory);
++        state_.reset(new State(directory, initial.size(),
++                               initially_available ? total : 0, counters));
+     }
+ 
+     py::object mutate_packed(const py::handle& operations) {
+@@ -409,14 +499,27 @@
+             std::memcpy(operation_bytes.data(), PyBytes_AS_STRING(operations.ptr()),
+                         expected);
+ 
+-        std::vector<Interval> scratch;
+-        Coordinate scratch_total;
++        StatePtr base_state;
+         {
+             std::lock_guard<std::mutex> lock(state_mutex_);
+             maybe_fail("state_copy");
+-            scratch = state_;
+-            scratch_total = total_;
++            base_state = state_;
+         }
++        maybe_fail("directory_clone");
++        const bool use_vector_scratch = base_state->directory.size() <= 1;
++        std::vector<BlockPtr> scratch;
++        std::vector<Interval> vector_scratch;
++        Coordinate scratch_total = base_state->total;
++        std::size_t scratch_live = base_state->live_count;
++        StorageCounters counters;
++        counters.directory_entries_copied = base_state->directory.size();
++        if (use_vector_scratch) {
++            if (!base_state->directory.empty())
++                vector_scratch = base_state->directory.front()->intervals;
++            counters.intervals_copied = vector_scratch.size();
++        } else {
++            scratch = base_state->directory;
++        }
+ 
+         std::vector<std::uint64_t> offsets;
+         std::vector<Interval> changed_spans;
+@@ -451,7 +554,7 @@
+                 }
+                 maybe_fail("row_staging");
+                 const std::size_t row_work = checked_size_add(
+-                    scratch.size(), 1, "work unit count overflow");
++                    scratch_live, 1, "work unit count overflow");
+                 work_units = checked_size_add(work_units, row_work,
+                                               "work unit count overflow");
+                 if (work_units > limits_.work_units) limit_error("max_work_units");
+@@ -469,16 +572,31 @@
+                     operation_error(
+                         index,
+                         "span is outside or crosses a managed-domain component");
+-                const bool covered = fully_covered(scratch, start, end);
++                const bool covered =
++                    use_vector_scratch
++                        ? fully_covered(vector_scratch, start, end)
++                        : fully_covered_directory(scratch, start, end);
+                 std::vector<Interval> changed;
+-                if (opcode == 0) {
+-                    changed = add_span(scratch, start, end);
++                if (use_vector_scratch) {
++                    if (opcode == 0) {
++                        changed = add_span(vector_scratch, start, end);
++                    } else if (opcode == 2 && !covered) {
++                        // Strict rejection is an exact no-op.
++                    } else {
++                        changed = discard_span(vector_scratch, start, end);
++                    }
++                    scratch_live = vector_scratch.size();
++                } else if (opcode == 0) {
++                    if (!covered)
++                        changed = mutate_directory(scratch, start, end, true,
++                                                   scratch_live, counters);
+                 } else if (opcode == 2 && !covered) {
+                     // Strict rejection is an exact no-op.
+-                } else {
+-                    changed = discard_span(scratch, start, end);
++                } else if (has_overlap(scratch, start, end)) {
++                    changed = mutate_directory(scratch, start, end, false,
++                                               scratch_live, counters);
+                 }
+-                if (scratch.size() > limits_.live_intervals)
++                if (scratch_live > limits_.live_intervals)
+                     limit_error("max_live_intervals");
+ 
+                 Coordinate changed_length = 0;
+@@ -573,22 +691,87 @@
+             prepared = py::cast(packed);
+         }
+ 
++        if (use_vector_scratch) {
++            const std::size_t old_blocks = base_state->directory.size();
++            const std::size_t new_blocks =
++                vector_scratch.empty()
++                    ? 0
++                    : checked_size_add(vector_scratch.size(),
++                                       kTargetBlockIntervals - 1,
++                                       "block count overflow") /
++                          kTargetBlockIntervals;
++            if (new_blocks > old_blocks) maybe_fail("block_split");
++            scratch.reserve(new_blocks);
++            for (std::size_t begin = 0; begin < vector_scratch.size();
++                 begin += kTargetBlockIntervals) {
++                const std::size_t end = std::min(
++                    vector_scratch.size(), begin + kTargetBlockIntervals);
++                std::vector<Interval> chunk(vector_scratch.begin() + begin,
++                                            vector_scratch.begin() + end);
++                maybe_fail("block_rebuild");
++                scratch.push_back(std::make_shared<IntervalBlock>(chunk));
++            }
++            counters.blocks_rebuilt = scratch.size();
++            counters.block_delta = static_cast<std::int64_t>(new_blocks) -
++                                   static_cast<std::int64_t>(old_blocks);
++            maybe_fail("directory_replacement");
++        }
++
++        counters.generation =
++            base_state->counters.generation ==
++                    std::numeric_limits<std::uint64_t>::max()
++                ? base_state->counters.generation
++                : base_state->counters.generation + 1;
++        counters.live_count = scratch_live;
++        counters.block_count = scratch.size();
++        counters.retained_estimated_bytes = retained_storage_bytes(scratch);
++        counters.transient_estimated_bytes = sizeof(State);
++        estimated_array_add(counters.transient_estimated_bytes,
++                            counters.directory_entries_copied,
++                            sizeof(BlockPtr));
++        estimated_array_add(counters.transient_estimated_bytes,
++                            counters.intervals_copied, sizeof(Interval));
++        estimated_array_add(counters.transient_estimated_bytes,
++                            counters.blocks_rebuilt, sizeof(IntervalBlock));
++
++        maybe_fail("root_creation");
++        StatePtr prepared_state(
++            new State(scratch, scratch_live, scratch_total, counters));
++        StatePtr displaced;
+         {
+             std::lock_guard<std::mutex> lock(state_mutex_);
+-            state_.swap(scratch);  // allocation-free and noexcept
+-            total_ = scratch_total;
++            displaced.swap(state_);
++            state_.swap(prepared_state);  // allocation-free and noexcept
+         }
++        displaced.reset();  // release the old root outside the publication latch
+         return prepared;
+     }
+ 
+     py::tuple snapshot_data() const {
++        StatePtr pinned;
+         std::vector<Interval> copy;
+         Coordinate total;
+         {
+             py::gil_scoped_release release;
+-            std::lock_guard<std::mutex> lock(state_mutex_);
+-            copy = state_;
+-            total = total_;
++            {
++                std::lock_guard<std::mutex> lock(state_mutex_);
++                pinned = state_;
++            }
++            {
++                std::unique_lock<std::mutex> latch_lock(snapshot_latch_mutex_);
++                if (snapshot_latch_armed_) {
++                    snapshot_latch_pinned_ = true;
++                    snapshot_latch_cv_.notify_all();
++                    snapshot_latch_cv_.wait(latch_lock, [this] {
++                        return !snapshot_latch_armed_;
++                    });
++                }
++            }
++            copy.reserve(pinned->live_count);
++            for (const auto& block : pinned->directory)
++                copy.insert(copy.end(), block->intervals.begin(),
++                            block->intervals.end());
++            total = pinned->total;
+         }
+         py::tuple intervals(
+             checked_shape(copy.size(), "snapshot tuple shape overflow"));
+@@ -598,11 +781,56 @@
+         return py::make_tuple(intervals, total);
+     }
+ 
++    void arm_snapshot_latch() {
++        std::lock_guard<std::mutex> lock(snapshot_latch_mutex_);
++        if (snapshot_latch_armed_)
++            throw py::value_error("snapshot latch is already armed");
++        snapshot_latch_pinned_ = false;
++        snapshot_latch_armed_ = true;
++    }
++
++    void wait_snapshot_latch() {
++        py::gil_scoped_release release;
++        std::unique_lock<std::mutex> lock(snapshot_latch_mutex_);
++        snapshot_latch_cv_.wait(lock, [this] {
++            return snapshot_latch_pinned_ || !snapshot_latch_armed_;
++        });
++    }
++
++    void release_snapshot_latch() {
++        std::lock_guard<std::mutex> lock(snapshot_latch_mutex_);
++        snapshot_latch_armed_ = false;
++        snapshot_latch_cv_.notify_all();
++    }
++
++    py::dict storage_counters() const {
++        StatePtr pinned;
++        {
++            std::lock_guard<std::mutex> lock(state_mutex_);
++            pinned = state_;
++        }
++        const auto& values = pinned->counters;
++        py::dict output;
++        output["directory_entries_copied"] = values.directory_entries_copied;
++        output["blocks_rebuilt"] = values.blocks_rebuilt;
++        output["intervals_copied"] = values.intervals_copied;
++        output["block_delta"] = values.block_delta;
++        output["generation"] = values.generation;
++        output["live_count"] = values.live_count;
++        output["block_count"] = values.block_count;
++        output["transient_estimated_bytes"] =
++            values.transient_estimated_bytes;
++        output["retained_estimated_bytes"] = values.retained_estimated_bytes;
++        return output;
++    }
++
+     void set_failpoint(const std::string& name, std::size_t occurrence) {
+         static const std::vector<std::string> names = {
+-            "operations_copy", "state_copy",       "result_reserve",
+-            "row_staging",    "packed_storage",   "python_bytes",
+-            "wrapper_preparation", "materialized_results"};
++            "operations_copy", "state_copy",       "directory_clone",
++            "result_reserve",  "row_staging",      "block_rebuild",
++            "block_split",     "packed_storage",   "python_bytes",
++            "wrapper_preparation", "materialized_results", "directory_replacement",
++            "root_creation"};
+         if (std::find(names.begin(), names.end(), name) == names.end())
+             throw py::value_error("unknown exact-batch failpoint");
+         std::lock_guard<std::mutex> lock(failpoint_mutex_);
+@@ -630,6 +858,132 @@
+         return length;
+     }
+ 
++    static void counter_add(std::size_t& value, std::size_t amount) noexcept {
++        if (amount > std::numeric_limits<std::size_t>::max() - value) {
++            value = std::numeric_limits<std::size_t>::max();
++        } else {
++            value += amount;
++        }
++    }
++
++    static bool fully_covered_directory(const std::vector<BlockPtr>& directory,
++                                        Coordinate start, Coordinate end) {
++        auto block = std::upper_bound(
++            directory.begin(), directory.end(), start,
++            [](Coordinate point, const BlockPtr& candidate) {
++                return point < candidate->first_start;
++            });
++        if (block != directory.begin()) --block;
++        if (block == directory.end() || (*block)->last_end <= start) return false;
++        const auto& intervals = (*block)->intervals;
++        auto interval = std::upper_bound(
++            intervals.begin(), intervals.end(), start,
++            [](Coordinate point, const Interval& candidate) {
++                return point < candidate.first;
++            });
++        if (interval != intervals.begin()) --interval;
++        return interval != intervals.end() && interval->first <= start &&
++               end <= interval->second;
++    }
++
++    static bool has_overlap(const std::vector<BlockPtr>& directory,
++                            Coordinate start, Coordinate end) {
++        auto block = std::upper_bound(
++            directory.begin(), directory.end(), start,
++            [](Coordinate point, const BlockPtr& candidate) {
++                return point < candidate->last_end;
++            });
++        for (; block != directory.end() && (*block)->first_start < end; ++block) {
++            const auto& intervals = (*block)->intervals;
++            auto interval = std::upper_bound(
++                intervals.begin(), intervals.end(), start,
++                [](Coordinate point, const Interval& candidate) {
++                    return point < candidate.second;
++                });
++            if (interval != intervals.end() && interval->first < end) return true;
++        }
++        return false;
++    }
++
++    std::vector<Interval> mutate_directory(std::vector<BlockPtr>& directory,
++                                           Coordinate start, Coordinate end,
++                                           bool adding,
++                                           std::size_t& live_count,
++                                           StorageCounters& counters) {
++        auto first = adding
++                         ? std::lower_bound(
++                               directory.begin(), directory.end(), start,
++                               [](const BlockPtr& block, Coordinate point) {
++                                   return block->last_end < point;
++                               })
++                         : std::upper_bound(
++                               directory.begin(), directory.end(), start,
++                               [](Coordinate point, const BlockPtr& block) {
++                                   return point < block->last_end;
++                               });
++        auto last = first;
++        if (adding) {
++            while (last != directory.end() && (*last)->first_start <= end) ++last;
++        } else {
++            while (last != directory.end() && (*last)->first_start < end) ++last;
++        }
++
++        std::size_t begin_index =
++            static_cast<std::size_t>(first - directory.begin());
++        std::size_t end_index =
++            static_cast<std::size_t>(last - directory.begin());
++        if (begin_index != 0) --begin_index;
++        if (end_index < directory.size()) ++end_index;
++
++        std::vector<Interval> local;
++        std::size_t local_count = 0;
++        for (std::size_t index = begin_index; index < end_index; ++index)
++            local_count = checked_size_add(local_count,
++                                           directory[index]->intervals.size(),
++                                           "local interval count overflow");
++        local.reserve(checked_size_add(local_count, adding ? 1 : 0,
++                                       "local interval count overflow"));
++        for (std::size_t index = begin_index; index < end_index; ++index) {
++            const auto& intervals = directory[index]->intervals;
++            local.insert(local.end(), intervals.begin(), intervals.end());
++        }
++        counter_add(counters.intervals_copied, local_count);
++
++        std::vector<Interval> changed =
++            adding ? add_span(local, start, end)
++                   : discard_span(local, start, end);
++        const std::size_t old_blocks = end_index - begin_index;
++        const std::size_t new_blocks =
++            local.empty()
++                ? 0
++                : checked_size_add(local.size(), kTargetBlockIntervals - 1,
++                                   "block count overflow") /
++                      kTargetBlockIntervals;
++        if (new_blocks > old_blocks) maybe_fail("block_split");
++
++        std::vector<BlockPtr> replacements;
++        replacements.reserve(new_blocks);
++        for (std::size_t begin = 0; begin < local.size();
++             begin += kTargetBlockIntervals) {
++            const std::size_t chunk_end =
++                std::min(local.size(), begin + kTargetBlockIntervals);
++            std::vector<Interval> chunk(local.begin() + begin,
++                                        local.begin() + chunk_end);
++            maybe_fail("block_rebuild");
++            replacements.push_back(std::make_shared<IntervalBlock>(chunk));
++        }
++        counter_add(counters.blocks_rebuilt, replacements.size());
++        counters.block_delta += static_cast<std::int64_t>(new_blocks) -
++                                static_cast<std::int64_t>(old_blocks);
++        directory.erase(directory.begin() + begin_index,
++                        directory.begin() + end_index);
++        directory.insert(directory.begin() + begin_index, replacements.begin(),
++                         replacements.end());
++        maybe_fail("directory_replacement");
++        live_count = live_count - local_count + local.size();
++        return changed;
++    }
++
+     bool inside_component(Coordinate start, Coordinate end) const {
+         auto item = std::upper_bound(
+             domain_.begin(), domain_.end(), start,
+@@ -651,8 +1005,11 @@
+ 
+     std::vector<Interval> domain_;
+     mutable std::mutex state_mutex_;
+-    std::vector<Interval> state_;
+-    Coordinate total_ = 0;
++    StatePtr state_;
++    mutable std::mutex snapshot_latch_mutex_;
++    mutable std::condition_variable snapshot_latch_cv_;
++    mutable bool snapshot_latch_armed_ = false;
++    mutable bool snapshot_latch_pinned_ = false;
+     Limits limits_;
+     std::atomic<bool> mutation_active_{false};
+     std::mutex failpoint_mutex_;
+@@ -703,6 +1060,10 @@
+         .def("mutate_materialized", &ExactBatchManager::mutate_materialized,
+              py::arg("operations"))
+         .def("snapshot_data", &ExactBatchManager::snapshot_data)
++        .def("_arm_snapshot_latch", &ExactBatchManager::arm_snapshot_latch)
++        .def("_wait_snapshot_latch", &ExactBatchManager::wait_snapshot_latch)
++        .def("_release_snapshot_latch", &ExactBatchManager::release_snapshot_latch)
++        .def("_storage_counters", &ExactBatchManager::storage_counters)
+         .def("_set_failpoint", &ExactBatchManager::set_failpoint,
+              py::arg("name"), py::arg("occurrence") = 0)
+         .def("_clear_failpoint", &ExactBatchManager::clear_failpoint);

--- a/tests/performance/experiments/lease_state_scaling.py
+++ b/tests/performance/experiments/lease_state_scaling.py
@@ -1,0 +1,1108 @@
+#!/usr/bin/env python3
+"""Fixed E4-B/D lease-state scaling and publication experiment."""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import json
+import platform
+import random
+import statistics
+import subprocess
+import time
+from dataclasses import replace
+from pathlib import Path
+from typing import Any, Callable, TypeVar
+
+from treemendous.applications._shared.clock import LogicalClock
+from treemendous.applications._shared.leasing import (
+    Lease,
+    LeaseDiagnostics,
+    LeasePool,
+    LeasePoolSnapshot,
+    LeaseState,
+)
+from treemendous.applications.leasing._common import PoolGroup
+from treemendous.backends.adapters import BackendAdapter
+from treemendous.basic.boundary import IntervalManager
+from treemendous.domain import Span
+from treemendous.rangeset import RangeSet
+
+SCHEMA = "treemendous-lease-state-scaling-experiment-v1"
+ACTIVE_LEASES = (128, 512, 2_048, 8_192)
+SMOKE_BLOCKS = 10
+CONFIRMATION_BLOCKS = 30
+FIXED_BLOCKS = (SMOKE_BLOCKS, CONFIRMATION_BLOCKS)
+BOOTSTRAP_RESAMPLES = 2_000
+BOOTSTRAP_SEED = 8_404_117
+READ_CYCLES = 16
+WRITE_CYCLES = 1
+FENCE_LIMIT = 0.50
+SNAPSHOT_LIMIT = 0.50
+NO_EXPIRY_LIMIT = 0.50
+NORMALIZED_SCALING_LIMIT = 2.0
+WRITE_REGRESSION_LIMIT = 1.10
+MEMORY_SETTLING_LIMIT = 1.10
+_KINDS = (
+    "repeated_snapshot",
+    "fence_validation",
+    "no_expiry_acquire_release",
+    "expiry_burst",
+)
+_GATE_RATIO_ORDER = (
+    "fence_n8192_upper",
+    "snapshot_n8192_upper",
+    "no_expiry_n8192_upper",
+    "candidate_no_expiry_n8192_over_n2048",
+    "write_cells_max_upper",
+    "memory_settling",
+)
+_SUMMARY_KEYS = {"median", "median_95_low", "median_95_high"}
+_BASE_ROW_KEYS = {
+    "kind",
+    "active_leases",
+    "cycles_per_position",
+    "validated_blocks",
+    "blocks",
+    "block_ratios",
+    "candidate_ns_per_cycle",
+    "baseline_ns_per_cycle",
+    "ratio",
+    "result_sha256",
+    "final_state_sha256",
+}
+_ROW_EXTRA_KEYS = {
+    "repeated_snapshot": set(),
+    "fence_validation": {"baseline_linear_lease_visits"},
+    "no_expiry_acquire_release": {
+        "candidate_active_lease_replays",
+        "baseline_active_lease_replays",
+    },
+    "expiry_burst": {"expired_per_cycle"},
+}
+BALANCED_BLOCK_METHOD = (
+    "each fixed block has two multi-cycle positions, one candidate-first and one "
+    "baseline-first; candidate and baseline durations are totaled within the "
+    "whole block; bootstrap units are whole blocks"
+)
+STOP_RULE = (
+    "Do not implement a lazy RangeSnapshot dataclass: the accepted exact immutable "
+    "projection caches already satisfy the generic unchanged-state use case."
+)
+_ROOT = Path(__file__).resolve().parents[3]
+_SOURCE_PATHS = (
+    "tests/performance/experiments/lease_state_scaling.py",
+    "treemendous/applications/_shared/leasing.py",
+    "treemendous/applications/leasing/_common.py",
+)
+T = TypeVar("T")
+
+
+def _seed_pool(
+    count: int, *, short_tail: int = 0
+) -> tuple[LeasePool, LogicalClock, list[Lease]]:
+    clock = LogicalClock()
+    pool = LeasePool((0, count + 1), clock=clock)
+    leases = [
+        pool.acquire(
+            f"owner-{index}",
+            ttl=2 if index >= count - short_tail else 1_000_000,
+            exact_span=(index, index + 1),
+        )
+        for index in range(count)
+    ]
+    return pool, clock, leases
+
+
+def _baseline_snapshot(pool: LeasePool) -> LeasePoolSnapshot:
+    """Faithfully construct the pre-cache public snapshot on unchanged state."""
+    with pool._lock:
+        now = pool._observe_time()
+        staged, free, _ = pool._stage_expirations(now)
+        leases = tuple(sorted(staged.values(), key=lambda lease: lease.token))
+        available = tuple(interval.span for interval in free.intervals())
+        states = tuple(lease.state for lease in staged.values())
+        diagnostics = LeaseDiagnostics(
+            observed_at=now,
+            total_capacity=pool._domain.measure,
+            available_capacity=sum(span.length for span in available),
+            largest_available_span=max((span.length for span in available), default=0),
+            active_leases=states.count(LeaseState.ACTIVE),
+            expired_leases=states.count(LeaseState.EXPIRED),
+            released_leases=states.count(LeaseState.RELEASED),
+            issued_tokens=pool._next_fencing_token - 1,
+            next_fencing_token=pool._next_fencing_token,
+        )
+        result = LeasePoolSnapshot(
+            now,
+            pool.pool_id,
+            pool.allowed_spans,
+            available,
+            leases,
+            diagnostics,
+        )
+        pool._commit(staged, free, now)
+        return result
+
+
+def _baseline_fence_lookup(pool: LeasePool, evidence: Lease, scans: list[int]) -> Lease:
+    """Reproduce the former public-snapshot plus linear token scan."""
+    snapshot = _baseline_snapshot(pool)
+    issued = None
+    for lease in snapshot.leases:
+        scans[0] += 1
+        if lease.token == evidence.token:
+            issued = lease
+            break
+    if issued is None:
+        raise AssertionError("seeded fence evidence was not issued")
+    if (
+        issued.owner != evidence.owner
+        or issued.resource != evidence.resource
+        or issued.acquired_at != evidence.acquired_at
+        or issued.request_id != evidence.request_id
+    ):
+        raise AssertionError("seeded fence evidence changed")
+    return issued
+
+
+def _elapsed(call: Callable[[], T]) -> tuple[int, T]:
+    started = time.perf_counter_ns()
+    result = call()
+    return time.perf_counter_ns() - started, result
+
+
+def _repeat(call: Callable[[], T], cycles: int) -> T:
+    result = call()
+    for _ in range(cycles - 1):
+        result = call()
+    return result
+
+
+def _bootstrap(values: list[float], seed: int) -> tuple[float, float]:
+    rng = random.Random(seed)
+    medians = sorted(
+        statistics.median(rng.choices(values, k=len(values)))
+        for _ in range(BOOTSTRAP_RESAMPLES)
+    )
+    return medians[int(0.025 * len(medians))], medians[int(0.975 * len(medians))]
+
+
+def _summary(values: list[float], seed: int) -> dict[str, float]:
+    low, high = _bootstrap(values, seed)
+    return {
+        "median": float(statistics.median(values)),
+        "median_95_low": low,
+        "median_95_high": high,
+    }
+
+
+def _digest(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(value, separators=(",", ":"), sort_keys=True).encode()
+    ).hexdigest()
+
+
+def _semantic_digests(kind: str, count: int) -> tuple[str, str]:
+    """Return fixed normalized semantics, independent of measured durations."""
+    result: Any
+    final: Any
+    if kind == "repeated_snapshot":
+        result = {
+            "available": [[count, count + 1]],
+            "leases": [
+                [index + 1, index, index + 1, "active"] for index in range(count)
+            ],
+        }
+        final = result
+    elif kind == "fence_validation":
+        result = {
+            "token": count,
+            "owner": f"owner-{count - 1}",
+            "resource": [count - 1, count],
+            "state": "active",
+        }
+        final = {"active_leases": count, "available": [[count, count + 1]]}
+    elif kind == "no_expiry_acquire_release":
+        result = {
+            "resource": [count, count + 1],
+            "released_state": "released",
+            "active_leases": count,
+        }
+        final = {"active_leases": count, "available": [[count, count + 1]]}
+    elif kind == "expiry_burst":
+        burst = max(1, count // 8)
+        result = [
+            [token, token - 1, token, "expired"]
+            for token in range(count - burst + 1, count + 1)
+        ]
+        final = {
+            "active_leases": count - burst,
+            "expired_leases": burst,
+            "available": [[count - burst, count + 1]],
+        }
+    else:
+        raise ValueError(f"unknown row kind: {kind}")
+    return _digest(result), _digest(final)
+
+
+def _balanced_row(
+    *,
+    kind: str,
+    count: int,
+    blocks: int,
+    cycles: int,
+    candidate: Callable[[], Any],
+    baseline: Callable[[], Any],
+    validate: Callable[[Any, Any], None],
+) -> dict[str, Any]:
+    raw: list[dict[str, Any]] = []
+    candidate_totals: list[int] = []
+    baseline_totals: list[int] = []
+    for block_index in range(blocks):
+        positions: list[dict[str, str | int]] = []
+        orders = (
+            ("candidate", "baseline")
+            if block_index % 2 == 0
+            else ("baseline", "candidate")
+        )
+        for first in orders:
+            if first == "candidate":
+                candidate_ns, candidate_result = _elapsed(
+                    lambda: _repeat(candidate, cycles)
+                )
+                baseline_ns, baseline_result = _elapsed(
+                    lambda: _repeat(baseline, cycles)
+                )
+            else:
+                baseline_ns, baseline_result = _elapsed(
+                    lambda: _repeat(baseline, cycles)
+                )
+                candidate_ns, candidate_result = _elapsed(
+                    lambda: _repeat(candidate, cycles)
+                )
+            validate(candidate_result, baseline_result)
+            positions.append(
+                {
+                    "first": first,
+                    "candidate_ns": candidate_ns,
+                    "baseline_ns": baseline_ns,
+                }
+            )
+        candidate_total = sum(int(item["candidate_ns"]) for item in positions)
+        baseline_total = sum(int(item["baseline_ns"]) for item in positions)
+        raw.append(
+            {
+                "block_index": block_index,
+                "positions": positions,
+                "candidate_ns_total": candidate_total,
+                "baseline_ns_total": baseline_total,
+                "ratio": candidate_total / baseline_total,
+            }
+        )
+        candidate_totals.append(candidate_total)
+        baseline_totals.append(baseline_total)
+    ratios = [
+        candidate_ns / baseline_ns
+        for candidate_ns, baseline_ns in zip(
+            candidate_totals, baseline_totals, strict=True
+        )
+    ]
+    seed = BOOTSTRAP_SEED + count * 17 + sum(map(ord, kind))
+    divisor = float(2 * cycles)
+    result_digest, final_digest = _semantic_digests(kind, count)
+    return {
+        "kind": kind,
+        "active_leases": count,
+        "cycles_per_position": cycles,
+        "validated_blocks": blocks,
+        "blocks": raw,
+        "block_ratios": ratios,
+        "candidate_ns_per_cycle": _summary(
+            [value / divisor for value in candidate_totals], seed + 1
+        ),
+        "baseline_ns_per_cycle": _summary(
+            [value / divisor for value in baseline_totals], seed + 2
+        ),
+        "ratio": _summary(ratios, seed),
+        "result_sha256": result_digest,
+        "final_state_sha256": final_digest,
+    }
+
+
+def _read_rows(count: int, blocks: int) -> list[dict[str, Any]]:
+    pool, _, leases = _seed_pool(count)
+    expected = pool.snapshot()
+    scans = [0]
+    snapshot_row = _balanced_row(
+        kind="repeated_snapshot",
+        count=count,
+        blocks=blocks,
+        cycles=READ_CYCLES,
+        candidate=pool.snapshot,
+        baseline=lambda: _baseline_snapshot(pool),
+        validate=lambda candidate, baseline: _validate_snapshots(
+            candidate, baseline, expected
+        ),
+    )
+    evidence = leases[-1]
+    fence_row = _balanced_row(
+        kind="fence_validation",
+        count=count,
+        blocks=blocks,
+        cycles=READ_CYCLES,
+        candidate=lambda: pool._lookup_fence_lease(evidence),
+        baseline=lambda: _baseline_fence_lookup(pool, evidence, scans),
+        validate=lambda candidate, baseline: _validate_fence(
+            candidate, baseline, evidence
+        ),
+    )
+    fence_row["baseline_linear_lease_visits"] = scans[0]
+    return [snapshot_row, fence_row]
+
+
+def _validate_snapshots(
+    candidate: LeasePoolSnapshot,
+    baseline: LeasePoolSnapshot,
+    expected: LeasePoolSnapshot,
+) -> None:
+    if candidate != baseline or candidate != expected:
+        raise AssertionError("snapshot paths diverged")
+    if (
+        type(candidate) is not LeasePoolSnapshot
+        or type(baseline) is not LeasePoolSnapshot
+    ):
+        raise AssertionError("snapshot exact type changed")
+
+
+def _validate_fence(candidate: Lease, baseline: Lease, expected: Lease) -> None:
+    if candidate != baseline or candidate != expected:
+        raise AssertionError("fence lookup paths diverged")
+
+
+def _observe_active_replays(pool: LeasePool, replays: list[int]) -> None:
+    original = pool._build_free
+
+    def rebuild_from_active(leases: dict[int, Lease]) -> Any:
+        replays[0] += sum(lease.state is LeaseState.ACTIVE for lease in leases.values())
+        return original(leases)
+
+    setattr(pool, "_build_free", rebuild_from_active)
+
+
+def _candidate_clone_free(pool: LeasePool, source: RangeSet) -> RangeSet:
+    """Clone committed canonical free intervals for experiment-only staging."""
+    staged = RangeSet(
+        BackendAdapter(IntervalManager()),
+        domain=pool._domain,
+        initially_available=False,
+    )
+    for interval in source.intervals():
+        staged.add(interval.span)
+    return staged
+
+
+def _candidate_stage_expirations(
+    pool: LeasePool, now: int
+) -> tuple[dict[int, Lease], RangeSet, tuple[Lease, ...]]:
+    """Apply the rejected authoritative-free delta without a runtime seam."""
+    expired = tuple(
+        lease
+        for lease in pool._leases.values()
+        if lease.state is LeaseState.ACTIVE and lease.expires_at <= now
+    )
+    if not expired:
+        return pool._leases, pool._free, ()
+    staged_leases = dict(pool._leases)
+    staged_free = _candidate_clone_free(pool, pool._free)
+    transitioned = []
+    for lease in sorted(expired, key=lambda item: item.token):
+        terminal = replace(lease, state=LeaseState.EXPIRED)
+        staged_leases[lease.token] = terminal
+        staged_free.add(lease.resource)
+        transitioned.append(terminal)
+    return staged_leases, staged_free, tuple(transitioned)
+
+
+def _candidate_acquire_exact(pool: LeasePool, owner: str, target: Span) -> Lease:
+    """Run Candidate D's clone/delta acquire entirely inside the experiment."""
+    with pool._lock:
+        now = pool._observe_time()
+        leases, free, _ = _candidate_stage_expirations(pool, now)
+        allocation_free = _candidate_clone_free(pool, free)
+        resource = pool._select_span(
+            allocation_free,
+            size=target.length,
+            alignment=1,
+            exact_span=target,
+        )
+        token = pool._next_fencing_token
+        lease = Lease(
+            pool.pool_id,
+            owner,
+            resource,
+            token,
+            now,
+            now + 1_000_000,
+        )
+        committed = dict(leases)
+        committed[token] = lease
+        pool._commit(committed, allocation_free, now)
+        pool._next_fencing_token = token + 1
+        return lease
+
+
+def _candidate_release(pool: LeasePool, handle: Lease) -> Lease:
+    """Run Candidate D's clone/delta release entirely inside the experiment."""
+    with pool._lock:
+        now = pool._observe_time()
+        leases, free, _ = _candidate_stage_expirations(pool, now)
+        current = pool._current_for(handle, leases, owner=None)
+        released = replace(current, state=LeaseState.RELEASED)
+        committed = dict(leases)
+        committed[current.token] = released
+        staged_free = _candidate_clone_free(pool, free)
+        staged_free.add(current.resource)
+        pool._commit(committed, staged_free, now)
+        return released
+
+
+def _candidate_expire(pool: LeasePool) -> tuple[Lease, ...]:
+    """Run Candidate D's free-delta expiry entirely inside the experiment."""
+    with pool._lock:
+        now = pool._observe_time()
+        leases, free, expired = _candidate_stage_expirations(pool, now)
+        pool._commit(leases, free, now)
+        return expired
+
+
+def _write_row(count: int, blocks: int) -> tuple[dict[str, Any], dict[str, int]]:
+    candidate_pool, _, _ = _seed_pool(count)
+    baseline_pool, _, _ = _seed_pool(count)
+    baseline_replays = [0]
+    _observe_active_replays(baseline_pool, baseline_replays)
+    candidate_replays = [0]
+    _observe_active_replays(candidate_pool, candidate_replays)
+    target = Span(count, count + 1)
+
+    def candidate_cycle() -> tuple[Span, LeaseState, int]:
+        lease = _candidate_acquire_exact(candidate_pool, "candidate", target)
+        released = _candidate_release(candidate_pool, lease)
+        active = candidate_pool.snapshot().diagnostics.active_leases
+        return lease.resource, released.state, active
+
+    def baseline_cycle() -> tuple[Span, LeaseState, int]:
+        lease = baseline_pool.acquire("baseline", ttl=1_000_000, exact_span=target)
+        released = baseline_pool.release(lease)
+        active = baseline_pool.snapshot().diagnostics.active_leases
+        return lease.resource, released.state, active
+
+    row = _balanced_row(
+        kind="no_expiry_acquire_release",
+        count=count,
+        blocks=blocks,
+        cycles=WRITE_CYCLES,
+        candidate=candidate_cycle,
+        baseline=baseline_cycle,
+        validate=lambda candidate, baseline: _validate_write(
+            candidate, baseline, count
+        ),
+    )
+    instrumentation = {
+        "candidate_active_lease_replays": candidate_replays[0],
+        "baseline_active_lease_replays": baseline_replays[0],
+    }
+    row.update(instrumentation)
+    return row, instrumentation
+
+
+def _validate_write(candidate: Any, baseline: Any, count: int) -> None:
+    expected = (Span(count, count + 1), LeaseState.RELEASED, count)
+    if candidate != expected or baseline != expected:
+        raise AssertionError("restorative write paths diverged")
+
+
+def _baseline_expire(pool: LeasePool) -> tuple[Lease, ...]:
+    with pool._lock:
+        now = pool._observe_time()
+        expired = tuple(
+            lease
+            for lease in pool._leases.values()
+            if lease.state is LeaseState.ACTIVE and lease.expires_at <= now
+        )
+        staged = dict(pool._leases)
+        transitioned = []
+        for lease in sorted(expired, key=lambda item: item.token):
+            terminal = replace(lease, state=LeaseState.EXPIRED)
+            staged[lease.token] = terminal
+            transitioned.append(terminal)
+        free = pool._build_free(staged)
+        pool._commit(staged, free, now)
+        return tuple(transitioned)
+
+
+def _expiry_row(count: int, blocks: int) -> dict[str, Any]:
+    burst = max(1, count // 8)
+    source, _, _ = _seed_pool(count, short_tail=burst)
+    checkpoint = source.checkpoint()
+    candidate_queue: list[LeasePool] = []
+    baseline_queue: list[LeasePool] = []
+
+    def prepare() -> None:
+        candidate_clock = LogicalClock()
+        baseline_clock = LogicalClock()
+        candidate = LeasePool.from_checkpoint(checkpoint, clock=candidate_clock)
+        baseline = LeasePool.from_checkpoint(checkpoint, clock=baseline_clock)
+        candidate_clock.advance(2)
+        baseline_clock.advance(2)
+        candidate_queue.append(candidate)
+        baseline_queue.append(baseline)
+
+    # Setup is deliberately outside timers. Each block has two positions.
+    for _ in range(blocks * 2):
+        prepare()
+
+    row = _balanced_row(
+        kind="expiry_burst",
+        count=count,
+        blocks=blocks,
+        cycles=1,
+        candidate=lambda: _candidate_expire(candidate_queue.pop(0)),
+        baseline=lambda: _baseline_expire(baseline_queue.pop(0)),
+        validate=lambda candidate, baseline: _validate_expiry(
+            candidate, baseline, burst
+        ),
+    )
+    row["expired_per_cycle"] = burst
+    return row
+
+
+def _validate_expiry(
+    candidate: tuple[Lease, ...], baseline: tuple[Lease, ...], burst: int
+) -> None:
+    normalized_candidate = tuple(
+        (lease.token, lease.resource, lease.state) for lease in candidate
+    )
+    normalized_baseline = tuple(
+        (lease.token, lease.resource, lease.state) for lease in baseline
+    )
+    if normalized_candidate != normalized_baseline or len(candidate) != burst:
+        raise AssertionError("expiry paths diverged")
+
+
+def _fence_instrumentation() -> dict[str, int]:
+    group = PoolGroup({"scope": (Span(0, 4),)}, clock=LogicalClock())
+    handle = group.acquire("scope", "owner", ttl=10)
+    pool = group.pool("scope")
+    calls = {"public_snapshot_calls": 0, "linear_lease_scans": 0}
+    original_snapshot = pool.snapshot
+    original_projection = pool._lease_projection
+
+    def snapshot() -> LeasePoolSnapshot:
+        calls["public_snapshot_calls"] += 1
+        return original_snapshot()
+
+    def projection(leases: dict[int, Lease]) -> tuple[Lease, ...]:
+        calls["linear_lease_scans"] += len(leases)
+        return original_projection(leases)
+
+    setattr(pool, "snapshot", snapshot)
+    setattr(pool, "_lease_projection", projection)
+    if not group.validate_fence("key", handle):
+        raise AssertionError("valid issued fence was rejected")
+    return calls
+
+
+def _retained_bytes(pool: LeasePool) -> int:
+    import sys as _sys
+
+    values: list[object] = [
+        pool._free,
+        pool._free.intervals(),
+        pool._lease_projection_cache,
+        pool._available_projection_cache,
+        pool._state_counts_cache,
+    ]
+    return sum(_sys.getsizeof(value) for value in values if value is not None)
+
+
+def _memory_settling() -> dict[str, Any]:
+    pool, _, leases = _seed_pool(128)
+    current = leases[0]
+    checkpoints: dict[int, int] = {}
+    for cycle in range(1, 1_001):
+        current = pool.renew(current, ttl=1_000_000)
+        pool.snapshot()
+        if cycle in (100, 1_000):
+            gc.collect()
+            checkpoints[cycle] = _retained_bytes(pool)
+    ratio = checkpoints[1_000] / checkpoints[100]
+    return {
+        "restorative_cycles": 1_000,
+        "bytes_after_100": checkpoints[100],
+        "bytes_after_1000": checkpoints[1_000],
+        "settling_ratio": ratio,
+        "limit": MEMORY_SETTLING_LIMIT,
+    }
+
+
+def _gate(
+    rows: list[dict[str, Any]], instrumentation: dict[str, int], memory: dict[str, Any]
+) -> dict[str, Any]:
+    by_key = {(row["kind"], row["active_leases"]): row for row in rows}
+    fence = by_key[("fence_validation", 8_192)]["ratio"]["median_95_high"]
+    snapshot = by_key[("repeated_snapshot", 8_192)]["ratio"]["median_95_high"]
+    no_expiry = by_key[("no_expiry_acquire_release", 8_192)]["ratio"]["median_95_high"]
+    candidate_8192 = by_key[("no_expiry_acquire_release", 8_192)][
+        "candidate_ns_per_cycle"
+    ]["median"]
+    candidate_2048 = by_key[("no_expiry_acquire_release", 2_048)][
+        "candidate_ns_per_cycle"
+    ]["median"]
+    scaling = candidate_8192 / candidate_2048
+    write_rows = [
+        row
+        for row in rows
+        if row["kind"] in {"no_expiry_acquire_release", "expiry_burst"}
+    ]
+    write_max = max(row["ratio"]["median_95_high"] for row in write_rows)
+    b_checks = {
+        "fence_zero_public_snapshots": instrumentation["public_snapshot_calls"] == 0,
+        "fence_zero_linear_scans": instrumentation["linear_lease_scans"] == 0,
+        "fence_n8192_upper_at_most_0_50": fence <= FENCE_LIMIT,
+        "snapshot_n8192_upper_at_most_0_50": snapshot <= SNAPSHOT_LIMIT,
+    }
+    d_checks = {
+        "no_expiry_zero_active_replays": all(
+            row.get("candidate_active_lease_replays", 0) == 0
+            for row in write_rows
+            if row["kind"] == "no_expiry_acquire_release"
+        ),
+        "no_expiry_n8192_upper_at_most_0_50": no_expiry <= NO_EXPIRY_LIMIT,
+        "candidate_n8192_over_n2048_at_most_2": scaling <= NORMALIZED_SCALING_LIMIT,
+        "write_cells_upper_at_most_1_10": write_max <= WRITE_REGRESSION_LIMIT,
+        "retained_memory_settles_within_10_percent": memory["settling_ratio"]
+        <= MEMORY_SETTLING_LIMIT,
+    }
+    b_accepted = all(b_checks.values())
+    d_accepted = all(d_checks.values())
+    return {
+        "candidate_b": {
+            "decision": "ACCEPTED" if b_accepted else "REJECTED",
+            "checks": b_checks,
+        },
+        "candidate_d": {
+            "decision": "ACCEPTED" if d_accepted else "REJECTED",
+            "checks": d_checks,
+        },
+        "ratios": {
+            "fence_n8192_upper": fence,
+            "snapshot_n8192_upper": snapshot,
+            "no_expiry_n8192_upper": no_expiry,
+            "candidate_no_expiry_n8192_over_n2048": scaling,
+            "write_cells_max_upper": write_max,
+            "memory_settling": memory["settling_ratio"],
+        },
+    }
+
+
+def _source_entries() -> list[dict[str, str]]:
+    return [
+        {
+            "path": path,
+            "sha256": hashlib.sha256((_ROOT / path).read_bytes()).hexdigest(),
+        }
+        for path in _SOURCE_PATHS
+    ]
+
+
+def _provenance() -> dict[str, Any]:
+    sources = _source_entries()
+    source_state = hashlib.sha256(
+        "".join(item["sha256"] for item in sources).encode()
+    ).hexdigest()
+    try:
+        commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=_ROOT,
+            text=True,
+            capture_output=True,
+            check=True,
+        ).stdout.strip()
+    except (OSError, subprocess.CalledProcessError):
+        commit = "unknown"
+    return {
+        "git": {"commit": commit, "source_state_sha256": source_state},
+        "runtime": {
+            "python_version": platform.python_version(),
+            "python_implementation": platform.python_implementation(),
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+        },
+        "sources": sources,
+    }
+
+
+def _methodology(blocks: int = CONFIRMATION_BLOCKS) -> dict[str, Any]:
+    return {
+        "active_leases": list(ACTIVE_LEASES),
+        "blocks": blocks,
+        "balanced_block_method": BALANCED_BLOCK_METHOD,
+        "bootstrap_resamples": BOOTSTRAP_RESAMPLES,
+        "bootstrap_seed": BOOTSTRAP_SEED,
+        "same_instance_validation_outside_timing": True,
+        "baseline": "faithful pre-candidate construction and active-lease replay functions",
+        "stop_rule": STOP_RULE,
+    }
+
+
+def run_matrix(
+    *, blocks: int = CONFIRMATION_BLOCKS, sizes: tuple[int, ...] = ACTIVE_LEASES
+) -> dict[str, Any]:
+    if type(blocks) is not int or blocks not in FIXED_BLOCKS:
+        raise ValueError(f"blocks must be one of the fixed profiles: {FIXED_BLOCKS}")
+    rows: list[dict[str, Any]] = []
+    instrumentation = _fence_instrumentation()
+    for count in sizes:
+        rows.extend(_read_rows(count, blocks))
+        write_row, _ = _write_row(count, blocks)
+        rows.append(write_row)
+        rows.append(_expiry_row(count, blocks))
+    memory = _memory_settling()
+    gate = _gate(rows, instrumentation, memory) if sizes == ACTIVE_LEASES else None
+    return {
+        "schema": SCHEMA,
+        "blocks": blocks,
+        "methodology": _methodology(blocks),
+        "instrumentation": instrumentation,
+        "rows": rows,
+        "memory": memory,
+        "gate": gate,
+        "provenance": _provenance(),
+    }
+
+
+def _canonical(report: dict[str, Any]) -> bytes:
+    return (
+        json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    ).encode()
+
+
+def _markdown(report: dict[str, Any], digest: str) -> str:
+    lines = [
+        "# Lease state scaling experiment",
+        "",
+        f"JSON SHA-256: `{digest}`",
+        "",
+        "| Candidate | Decision |",
+        "| --- | --- |",
+    ]
+    gate = report["gate"]
+    if gate is None:
+        lines.extend(("| E4-B | diagnostic |", "| E4-D | diagnostic |"))
+    else:
+        lines.extend(
+            (
+                f"| E4-B | {gate['candidate_b']['decision']} |",
+                f"| E4-D | {gate['candidate_d']['decision']} |",
+                "",
+                "## Exact gate ratios",
+                "",
+            )
+        )
+        for name in _GATE_RATIO_ORDER:
+            lines.append(f"- `{name}`: {gate['ratios'][name]:.6f}")
+    lines.extend(("", "## Stop rule", "", STOP_RULE, ""))
+    return "\n".join(lines)
+
+
+def write_artifacts(report: dict[str, Any], output: Path) -> tuple[Path, Path, Path]:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    encoded = _canonical(report)
+    output.write_bytes(encoded)
+    digest = hashlib.sha256(encoded).hexdigest()
+    markdown = output.with_suffix(".md")
+    checksum = Path(f"{output}.sha256")
+    markdown.write_text(_markdown(report, digest))
+    checksum.write_text(f"{digest}  {output.name}\n")
+    return output, markdown, checksum
+
+
+def _reject_constant(value: str) -> Any:
+    raise ValueError(f"non-finite JSON constant: {value}")
+
+
+def _pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate key: {key}")
+        result[key] = value
+    return result
+
+
+def _exact(actual: Any, expected: Any) -> bool:
+    if type(actual) is not type(expected):
+        return False
+    if type(actual) is dict:
+        return actual.keys() == expected.keys() and all(
+            _exact(actual[key], expected[key]) for key in actual
+        )
+    if type(actual) is list:
+        return len(actual) == len(expected) and all(
+            _exact(left, right) for left, right in zip(actual, expected, strict=True)
+        )
+    return bool(actual == expected)
+
+
+def _require_keys(value: Any, keys: set[str], label: str) -> dict[str, Any]:
+    if type(value) is not dict or set(value) != keys:
+        raise ValueError(f"{label} schema mismatch")
+    return value
+
+
+def verify_artifacts(output: Path) -> dict[str, Any]:
+    encoded = output.read_bytes()
+    digest = hashlib.sha256(encoded).hexdigest()
+    expected_checksum = f"{digest}  {output.name}\n"
+    if Path(f"{output}.sha256").read_text() != expected_checksum:
+        raise ValueError("SHA-256 sidecar mismatch")
+    report = json.loads(
+        encoded,
+        object_pairs_hook=_pairs,
+        parse_constant=_reject_constant,
+    )
+    if encoded != _canonical(report):
+        raise ValueError("JSON is not canonical")
+    _require_keys(
+        report,
+        {
+            "schema",
+            "blocks",
+            "methodology",
+            "instrumentation",
+            "rows",
+            "memory",
+            "gate",
+            "provenance",
+        },
+        "report",
+    )
+    if type(report["schema"]) is not str or report["schema"] != SCHEMA:
+        raise ValueError("schema mismatch")
+    blocks_count = report["blocks"]
+    if type(blocks_count) is not int or blocks_count not in FIXED_BLOCKS:
+        raise ValueError("fixed block count mismatch")
+    if not _exact(report["methodology"], _methodology(blocks_count)):
+        raise ValueError("fixed methodology mismatch")
+
+    instrumentation = _require_keys(
+        report["instrumentation"],
+        {"public_snapshot_calls", "linear_lease_scans"},
+        "instrumentation",
+    )
+    if any(type(value) is not int for value in instrumentation.values()) or not _exact(
+        instrumentation, {"public_snapshot_calls": 0, "linear_lease_scans": 0}
+    ):
+        raise ValueError("instrumentation derivation mismatch")
+
+    memory = _require_keys(
+        report["memory"],
+        {
+            "restorative_cycles",
+            "bytes_after_100",
+            "bytes_after_1000",
+            "settling_ratio",
+            "limit",
+        },
+        "memory",
+    )
+    if (
+        type(memory["restorative_cycles"]) is not int
+        or memory["restorative_cycles"] != 1_000
+        or type(memory["bytes_after_100"]) is not int
+        or type(memory["bytes_after_1000"]) is not int
+        or min(memory["bytes_after_100"], memory["bytes_after_1000"]) <= 0
+        or type(memory["settling_ratio"]) is not float
+        or memory["settling_ratio"]
+        != memory["bytes_after_1000"] / memory["bytes_after_100"]
+        or type(memory["limit"]) is not float
+        or memory["limit"] != MEMORY_SETTLING_LIMIT
+    ):
+        raise ValueError("memory derivation mismatch")
+
+    rows = report["rows"]
+    expected_matrix = [(kind, count) for count in ACTIVE_LEASES for kind in _KINDS]
+    if type(rows) is not list or len(rows) != len(expected_matrix):
+        raise ValueError("fixed matrix mismatch")
+    observed_matrix: list[tuple[str, int]] = []
+    for row, expected_identity in zip(rows, expected_matrix, strict=True):
+        if type(row) is not dict:
+            raise ValueError("row exact type mismatch")
+        kind, count = expected_identity
+        if "kind" not in row or "active_leases" not in row:
+            raise ValueError("per-kind row schema mismatch")
+        if type(row["kind"]) is not str or type(row["active_leases"]) is not int:
+            raise ValueError("row identity exact type mismatch")
+        identity = (row["kind"], row["active_leases"])
+        observed_matrix.append(identity)
+        if identity != expected_identity:
+            raise ValueError("ordered unique matrix mismatch")
+        expected_keys = _BASE_ROW_KEYS | _ROW_EXTRA_KEYS[kind]
+        if set(row) != expected_keys:
+            raise ValueError("per-kind row schema mismatch")
+        expected_cycles = (
+            WRITE_CYCLES
+            if kind == "no_expiry_acquire_release"
+            else 1
+            if kind == "expiry_burst"
+            else READ_CYCLES
+        )
+        if (
+            type(row["cycles_per_position"]) is not int
+            or row["cycles_per_position"] != expected_cycles
+            or type(row["validated_blocks"]) is not int
+            or row["validated_blocks"] != blocks_count
+        ):
+            raise ValueError("row cycle/block mismatch")
+        expected_result, expected_final = _semantic_digests(kind, count)
+        if (
+            type(row["result_sha256"]) is not str
+            or row["result_sha256"] != expected_result
+            or type(row["final_state_sha256"]) is not str
+            or row["final_state_sha256"] != expected_final
+        ):
+            raise ValueError("semantic digest mismatch")
+        blocks = row["blocks"]
+        if type(blocks) is not list or len(blocks) != blocks_count:
+            raise ValueError("raw block mismatch")
+        candidate_totals: list[int] = []
+        baseline_totals: list[int] = []
+        for index, block in enumerate(blocks):
+            _require_keys(
+                block,
+                {
+                    "block_index",
+                    "positions",
+                    "candidate_ns_total",
+                    "baseline_ns_total",
+                    "ratio",
+                },
+                "block",
+            )
+            if type(block["block_index"]) is not int or block["block_index"] != index:
+                raise ValueError("block exact type/index mismatch")
+            positions = block["positions"]
+            expected_first = (
+                ["candidate", "baseline"]
+                if index % 2 == 0
+                else ["baseline", "candidate"]
+            )
+            if type(positions) is not list or len(positions) != 2:
+                raise ValueError("balanced block ordering mismatch")
+            for position, first in zip(positions, expected_first, strict=True):
+                _require_keys(
+                    position,
+                    {"first", "candidate_ns", "baseline_ns"},
+                    "position",
+                )
+                if type(position["first"]) is not str or position["first"] != first:
+                    raise ValueError("balanced block ordering mismatch")
+                if any(
+                    type(position[key]) is not int or position[key] <= 0
+                    for key in ("candidate_ns", "baseline_ns")
+                ):
+                    raise ValueError("exact timing type mismatch")
+            candidate_total = sum(item["candidate_ns"] for item in positions)
+            baseline_total = sum(item["baseline_ns"] for item in positions)
+            expected_ratio = candidate_total / baseline_total
+            if (
+                type(block["candidate_ns_total"]) is not int
+                or block["candidate_ns_total"] != candidate_total
+                or type(block["baseline_ns_total"]) is not int
+                or block["baseline_ns_total"] != baseline_total
+                or type(block["ratio"]) is not float
+                or block["ratio"] != expected_ratio
+            ):
+                raise ValueError("raw block derivation mismatch")
+            candidate_totals.append(candidate_total)
+            baseline_totals.append(baseline_total)
+        ratios = [a / b for a, b in zip(candidate_totals, baseline_totals, strict=True)]
+        seed = BOOTSTRAP_SEED + count * 17 + sum(map(ord, kind))
+        divisor = float(2 * expected_cycles)
+        for label, value in (
+            ("ratio", row["ratio"]),
+            ("candidate summary", row["candidate_ns_per_cycle"]),
+            ("baseline summary", row["baseline_ns_per_cycle"]),
+        ):
+            summary = _require_keys(value, _SUMMARY_KEYS, label)
+            if any(type(item) is not float for item in summary.values()):
+                raise ValueError("summary exact type mismatch")
+        if (
+            type(row["block_ratios"]) is not list
+            or any(type(value) is not float for value in row["block_ratios"])
+            or not _exact(row["block_ratios"], ratios)
+            or not _exact(row["ratio"], _summary(ratios, seed))
+            or not _exact(
+                row["candidate_ns_per_cycle"],
+                _summary([value / divisor for value in candidate_totals], seed + 1),
+            )
+            or not _exact(
+                row["baseline_ns_per_cycle"],
+                _summary([value / divisor for value in baseline_totals], seed + 2),
+            )
+        ):
+            raise ValueError("derived ratio or timing summary mismatch")
+        if kind == "fence_validation" and (
+            type(row["baseline_linear_lease_visits"]) is not int
+            or row["baseline_linear_lease_visits"]
+            != count * blocks_count * 2 * READ_CYCLES
+        ):
+            raise ValueError("fence instrumentation derivation mismatch")
+        if kind == "no_expiry_acquire_release" and (
+            type(row["candidate_active_lease_replays"]) is not int
+            or row["candidate_active_lease_replays"] != 0
+            or type(row["baseline_active_lease_replays"]) is not int
+            or row["baseline_active_lease_replays"] != count * blocks_count * 4
+        ):
+            raise ValueError("write instrumentation derivation mismatch")
+        if kind == "expiry_burst" and (
+            type(row["expired_per_cycle"]) is not int
+            or row["expired_per_cycle"] != max(1, count // 8)
+        ):
+            raise ValueError("expiry semantics mismatch")
+    if observed_matrix != expected_matrix or len(set(observed_matrix)) != len(
+        expected_matrix
+    ):
+        raise ValueError("ordered unique matrix mismatch")
+
+    expected_gate = _gate(rows, instrumentation, memory)
+    if not _exact(report["gate"], expected_gate):
+        raise ValueError("gate mismatch")
+    if not _exact(report["provenance"], _provenance()):
+        raise ValueError("source/runtime provenance mismatch")
+    if output.with_suffix(".md").read_text() != _markdown(report, digest):
+        raise ValueError("Markdown mismatch")
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--blocks", type=int, default=CONFIRMATION_BLOCKS)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--verify", action="store_true")
+    args = parser.parse_args()
+    if args.verify:
+        verify_artifacts(args.output)
+        print(f"verified {args.output}")
+        return
+    report = run_matrix(blocks=args.blocks)
+    paths = write_artifacts(report, args.output)
+    print(json.dumps(report["gate"], indent=2, sort_keys=True))
+    print("\n".join(str(path) for path in paths))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/performance/experiments/radio_spectrum_index_matrix.py
+++ b/tests/performance/experiments/radio_spectrum_index_matrix.py
@@ -1,0 +1,2048 @@
+#!/usr/bin/env python3
+"""Radio-spectrum BoxIndex injection and adaptive-representation experiment.
+
+This module is deliberately experiment-only.  It replaces ``scheduler._index``
+only while the newly constructed scheduler is empty; no production factory,
+constructor, decision policy, or live migration path is added.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import hashlib
+import inspect
+import json
+import math
+import os
+import platform
+import random
+import resource
+import statistics
+import subprocess
+import sys
+import time
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any, Literal
+
+from treemendous.applications.scheduling.radio_spectrum import (
+    RadioSpectrumScheduler,
+    SpectrumConflictError,
+    SpectrumReservation,
+    SpectrumStatus,
+)
+from treemendous.multidimensional import BoundedBoxIndex, Box, BoxIndex, BoxIndex2D
+
+SCHEMA = "treemendous-radio-spectrum-index-matrix-v2"
+POLICY_VERSION = "radio-spectrum-index-policy-v2"
+MINIMUM_BLOCKS = 25
+TRAINING_SIZES = (32, 128, 512, 2_000, 10_000)
+HELD_OUT_SIZES = (64, 256, 1_000, 5_000)
+CHANNEL_COUNT = 64
+OPERATIONS_PER_POSITION = 8
+BOOTSTRAP_RESAMPLES = 2_000
+BOOTSTRAP_SEED = 7_316_219
+PROJECTION_ELIGIBILITY_LIMIT = 0.80
+SELECTED_CELL_LIMIT = 0.90
+HELD_OUT_SELECTED_LIMIT = 0.90
+DEFAULT_LINEAR_LIMIT = 1.10
+DEFAULT_LINEAR_CONTROL_SIZE = 512
+DEFAULT_LINEAR_CONTROL_SEED = 527_911
+MEMORY_LIMIT = 1.25
+GRID_LIMITS = {
+    "max_total_cells": 20_000,
+    "max_cells_per_entry": 32,
+    "max_cells_per_query": 20_000,
+    "max_total_postings": 200_000,
+    "max_estimated_bytes": 128 * 1024 * 1024,
+}
+CANDIDATES = ("projection", "grid")
+BUILD_FLAG_NAMES = (
+    "BOOST_ROOT",
+    "TREE_MENDOUS_DISABLE_OPTIMIZATIONS",
+    "TREE_MENDOUS_GLIBCXX_DEBUG",
+    "TREE_MENDOUS_LOCAL_NATIVE",
+    "TREE_MENDOUS_SANITIZERS",
+    "TREE_MENDOUS_WITH_ICL",
+)
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+_SOURCE_PATHS = (
+    "tests/performance/experiments/radio_spectrum_index_matrix.py",
+    "treemendous/applications/scheduling/radio_spectrum.py",
+    "treemendous/multidimensional/index.py",
+    "treemendous/multidimensional/diagnostics.py",
+    "treemendous/multidimensional/algorithms/projection.py",
+    "treemendous/multidimensional/algorithms/grid.py",
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class Scenario:
+    """One fixed query shape, density, mutation mix, and skew cell."""
+
+    name: str
+    density: Literal["low", "medium", "high"]
+    channel_query: Literal["narrow", "broad"]
+    time_query: Literal["narrow", "broad"]
+    insertion_cancellation_ratio: Literal["3:1", "2:2", "1:3", "replay"]
+    axis_skew: Literal["balanced", "channel", "time", "both"]
+
+
+SCENARIOS = (
+    Scenario("low-narrow-narrow", "low", "narrow", "narrow", "3:1", "balanced"),
+    Scenario("medium-broad-channel", "medium", "broad", "narrow", "2:2", "channel"),
+    Scenario("medium-broad-time", "medium", "narrow", "broad", "2:2", "time"),
+    Scenario("high-broad-both", "high", "broad", "broad", "1:3", "both"),
+    Scenario(
+        "idempotent-replay",
+        "medium",
+        "narrow",
+        "narrow",
+        "replay",
+        "balanced",
+    ),
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class _OracleRecord:
+    reservation: SpectrumReservation
+    box: Box
+
+
+class _RadioOracle:
+    """Independent sorted-list radio conflict oracle (no BoxIndex dependency)."""
+
+    def __init__(self, channel_count: int) -> None:
+        self.channel_count = channel_count
+        self.records: dict[str, _OracleRecord] = {}
+        self.next_by_owner: dict[str, int] = {}
+        self.requests: dict[tuple[str, str], tuple[tuple[int, ...], str]] = {}
+        self.version = 0
+
+    def _box(
+        self, channel_start: int, channel_width: int, start: int, end: int, guard: int
+    ) -> Box:
+        if channel_width < 1 or channel_start + channel_width > self.channel_count:
+            raise ValueError("requested channels exceed the managed channel domain")
+        return Box(
+            (max(0, channel_start - guard), start),
+            (min(self.channel_count, channel_start + channel_width + guard), end),
+        )
+
+    def overlaps(self, box: Box) -> tuple[str, ...]:
+        return tuple(
+            sorted(
+                record.reservation.id
+                for record in self.records.values()
+                if record.reservation.active and record.box.overlaps(box)
+            )
+        )
+
+    def reserve(
+        self,
+        owner: str,
+        channel_start: int,
+        channel_width: int,
+        start: int,
+        end: int,
+        *,
+        guard_channels: int = 0,
+        request_id: str | None = None,
+    ) -> SpectrumReservation:
+        fingerprint = (channel_start, channel_width, start, end, guard_channels)
+        if request_id is not None:
+            prior = self.requests.get((owner, request_id))
+            if prior is not None:
+                if prior[0] != fingerprint:
+                    raise ValueError(
+                        "idempotency key was already used for a different request"
+                    )
+                return self.records[prior[1]].reservation
+        box = self._box(channel_start, channel_width, start, end, guard_channels)
+        conflicts = self.overlaps(box)
+        if conflicts:
+            raise SpectrumConflictError(
+                # Use the production value carrier, but not its index or algorithm.
+                __import__(
+                    "treemendous.applications.scheduling.radio_spectrum",
+                    fromlist=["SpectrumConflict"],
+                ).SpectrumConflict(box, conflicts)
+            )
+        sequence = self.next_by_owner.get(owner, 1)
+        reservation_id = f"{owner}:{sequence}"
+        reservation = SpectrumReservation(
+            reservation_id,
+            owner,
+            channel_start,
+            channel_start + channel_width,
+            start,
+            end,
+            guard_channels,
+            request_id,
+        )
+        self.records[reservation_id] = _OracleRecord(reservation, box)
+        self.next_by_owner[owner] = sequence + 1
+        if request_id is not None:
+            self.requests[(owner, request_id)] = fingerprint, reservation_id
+        self.version += 1
+        return reservation
+
+    def conflicts_for(
+        self,
+        channel_start: int,
+        channel_width: int,
+        start: int,
+        end: int,
+        *,
+        guard_channels: int = 0,
+    ) -> tuple[Box, tuple[str, ...]] | None:
+        box = self._box(channel_start, channel_width, start, end, guard_channels)
+        conflicts = self.overlaps(box)
+        return None if not conflicts else (box, conflicts)
+
+    def cancel(self, owner: str, reservation_id: str) -> SpectrumReservation:
+        record = self.records.get(reservation_id)
+        if record is None:
+            raise KeyError(reservation_id)
+        if record.reservation.owner != owner:
+            raise PermissionError("reservation belongs to a different owner")
+        if not record.reservation.active:
+            return record.reservation
+        cancelled = dataclasses.replace(
+            record.reservation, status=SpectrumStatus.CANCELLED
+        )
+        self.records[reservation_id] = _OracleRecord(cancelled, record.box)
+        self.version += 1
+        return cancelled
+
+
+def _time_upper(active_entries: int, blocks: int, scenario_count: int) -> int:
+    # The most channel-skewed seed uses 16 channel positions with an eight-unit
+    # low-density stride. Mutation reservations occupy disjoint later windows.
+    seed_upper = ((active_entries + 15) // 16) * 8
+    return max(1_024, seed_upper + blocks * scenario_count * 8 + 64)
+
+
+def _new_index(
+    kind: str, *, active_entries: int, blocks: int, scenario_count: int
+) -> Any:
+    if kind == "linear":
+        return BoxIndex(2)
+    if kind == "projection":
+        return BoxIndex2D()
+    if kind == "grid":
+        upper = _time_upper(active_entries, blocks, scenario_count)
+        return BoundedBoxIndex(
+            Box((0, 0), (CHANNEL_COUNT, upper)),
+            (4, 8),
+            max_total_cells=GRID_LIMITS["max_total_cells"],
+            max_cells_per_entry=GRID_LIMITS["max_cells_per_entry"],
+            max_cells_per_query=GRID_LIMITS["max_cells_per_query"],
+            max_total_postings=GRID_LIMITS["max_total_postings"],
+            max_estimated_bytes=GRID_LIMITS["max_estimated_bytes"],
+        )
+    raise ValueError(f"unknown experiment index: {kind}")
+
+
+def _new_scheduler(
+    kind: str, *, active_entries: int, blocks: int, scenario_count: int
+) -> RadioSpectrumScheduler:
+    """Inject one index into an empty real scheduler, with no fallback path."""
+    scheduler = RadioSpectrumScheduler(CHANNEL_COUNT)
+    if scheduler._records or len(scheduler._index) or scheduler._index.dimensions != 2:
+        raise AssertionError("experiment injection requires a new empty scheduler")
+    scheduler._index = _new_index(
+        kind,
+        active_entries=active_entries,
+        blocks=blocks,
+        scenario_count=scenario_count,
+    )
+    return scheduler
+
+
+def _seed_profile(scenario: Scenario) -> tuple[tuple[int, ...], int, int]:
+    channels = {
+        "balanced": tuple(range(0, CHANNEL_COUNT, 2)),
+        "channel": tuple(range(24, 40)),
+        "time": tuple(range(CHANNEL_COUNT)),
+        "both": tuple(range(24, 40)),
+    }[scenario.axis_skew]
+    duration, stride = {
+        "low": (1, 8),
+        "medium": (2, 4),
+        "high": (3, 3),
+    }[scenario.density]
+    return channels, duration, stride
+
+
+def _seed_arguments(scenario: Scenario, index: int) -> dict[str, Any]:
+    channels, duration, stride = _seed_profile(scenario)
+    start = (index // len(channels)) * stride
+    return {
+        "owner": f"seed-{index}",
+        "channel_start": channels[index % len(channels)],
+        "channel_width": 1,
+        "start": start,
+        "end": start + duration,
+        "guard_channels": 0,
+        "request_id": f"seed-request-{index}",
+    }
+
+
+def _seed_oracle(scenario: Scenario, active_entries: int) -> _RadioOracle:
+    oracle = _RadioOracle(CHANNEL_COUNT)
+    for index in range(active_entries):
+        oracle.reserve(**_seed_arguments(scenario, index))
+    return oracle
+
+
+def _seed_scheduler(
+    scheduler: RadioSpectrumScheduler, active_entries: int, scenario: Scenario
+) -> _RadioOracle:
+    oracle = _RadioOracle(CHANNEL_COUNT)
+    for index in range(active_entries):
+        arguments = _seed_arguments(scenario, index)
+        actual = scheduler.reserve(**arguments)
+        expected = oracle.reserve(**arguments)
+        if actual != expected:
+            raise AssertionError("seed reservation diverged from independent oracle")
+    _assert_state(scheduler, oracle)
+    return oracle
+
+
+def _rss_bytes() -> int:
+    value = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    return int(value if sys.platform == "darwin" else value * 1024)
+
+
+def _deep_size(root: Any) -> int:
+    """Deterministic CPython retained-graph proxy with identity de-duplication."""
+    seen: set[int] = set()
+
+    def visit(value: Any) -> int:
+        identity = id(value)
+        if identity in seen:
+            return 0
+        seen.add(identity)
+        total = sys.getsizeof(value)
+        if isinstance(value, dict):
+            return total + sum(visit(key) + visit(item) for key, item in value.items())
+        if isinstance(value, (tuple, list, set, frozenset)):
+            return total + sum(visit(item) for item in value)
+        namespace = getattr(value, "__dict__", None)
+        if isinstance(namespace, dict):
+            total += visit(namespace)
+        slots = getattr(type(value), "__slots__", ())
+        if isinstance(slots, str):
+            slots = (slots,)
+        for slot in slots:
+            if hasattr(value, slot):
+                total += visit(getattr(value, slot))
+        return total
+
+    return visit(root)
+
+
+def _construct(
+    kind: str,
+    *,
+    active_entries: int,
+    blocks: int,
+    scenario_count: int,
+    scenario: Scenario,
+) -> tuple[RadioSpectrumScheduler, _RadioOracle, dict[str, int | str]]:
+    rss_before = _rss_bytes()
+    started = time.perf_counter_ns()
+    scheduler = _new_scheduler(
+        kind,
+        active_entries=active_entries,
+        blocks=blocks,
+        scenario_count=scenario_count,
+    )
+    oracle = _seed_scheduler(scheduler, active_entries, scenario)
+    construction_ns = time.perf_counter_ns() - started
+    rss_after = _rss_bytes()
+    return (
+        scheduler,
+        oracle,
+        {
+            "algorithm": scheduler._index.diagnostics().algorithm,
+            "construction_ns": construction_ns,
+            "retained_bytes": _deep_size(scheduler._index),
+            "rss_before_bytes": rss_before,
+            "rss_after_bytes": rss_after,
+            "rss_high_water_delta_bytes": max(0, rss_after - rss_before),
+        },
+    )
+
+
+def _reservation(value: SpectrumReservation) -> dict[str, Any]:
+    return {
+        "id": value.id,
+        "owner": value.owner,
+        "channel_start": value.channel_start,
+        "channel_end": value.channel_end,
+        "start": value.start,
+        "end": value.end,
+        "guard_channels": value.guard_channels,
+        "request_id": value.request_id,
+        "status": value.status.value,
+    }
+
+
+def _state(scheduler: RadioSpectrumScheduler) -> dict[str, Any]:
+    snapshot = scheduler.snapshot()
+    diagnostics = scheduler._index.diagnostics()
+    return {
+        "reservations": [_reservation(item) for item in snapshot.reservations],
+        "geometry": {
+            "dimensions": snapshot.geometry.dimensions,
+            "version": snapshot.geometry.version,
+            "entries": [
+                {
+                    "sequence": entry.handle.sequence,
+                    "lower": list(entry.box.lower),
+                    "upper": list(entry.box.upper),
+                    "data": entry.data,
+                }
+                for entry in snapshot.geometry.entries
+            ],
+        },
+        "diagnostics": {
+            "algorithm": diagnostics.algorithm,
+            "dimensions": diagnostics.dimensions,
+            "version": diagnostics.version,
+            "entry_count": diagnostics.entry_count,
+            "distinct_box_count": diagnostics.distinct_box_count,
+            "duplicate_entry_count": diagnostics.duplicate_entry_count,
+            "projection_sizes": list(diagnostics.projection_sizes),
+            "posting_count": diagnostics.posting_count,
+            "occupied_cell_count": diagnostics.occupied_cell_count,
+            "estimated_memory_bytes": diagnostics.estimated_memory_bytes,
+        },
+    }
+
+
+def _oracle_state(oracle: _RadioOracle, algorithm: str) -> dict[str, Any]:
+    reservations = sorted(
+        (record.reservation for record in oracle.records.values()),
+        key=lambda item: (item.start, item.channel_start, item.id),
+    )
+    active = [
+        record
+        for record in oracle.records.values()
+        if record.reservation.status is SpectrumStatus.ACTIVE
+    ]
+    # Handles are allocated monotonically only for successful insertions.
+    entries = []
+    sequence = 0
+    for record in oracle.records.values():
+        if record.reservation.active:
+            # Record iteration order includes cancelled history; recover the handle
+            # sequence from successful-insert order by counting all records.
+            pass
+    active_ids = {record.reservation.id for record in active}
+    for sequence, record in enumerate(oracle.records.values(), 1):
+        if record.reservation.id in active_ids:
+            entries.append(
+                {
+                    "sequence": sequence,
+                    "lower": list(record.box.lower),
+                    "upper": list(record.box.upper),
+                    "data": record.reservation.id,
+                }
+            )
+    boxes = [record.box for record in active]
+    distinct = len(set(boxes))
+    strategy = {
+        "algorithm": algorithm,
+        "dimensions": 2,
+        "version": oracle.version,
+        "entry_count": len(active),
+        "distinct_box_count": distinct,
+        "duplicate_entry_count": len(active) - distinct,
+        "projection_sizes": [len(active), len(active)]
+        if algorithm == "axis_projection"
+        else [],
+        "posting_count": None,
+        "occupied_cell_count": None,
+        "estimated_memory_bytes": None,
+    }
+    return {
+        "reservations": [_reservation(item) for item in reservations],
+        "geometry": {"dimensions": 2, "version": oracle.version, "entries": entries},
+        "diagnostics": strategy,
+    }
+
+
+def _assert_state(scheduler: RadioSpectrumScheduler, oracle: _RadioOracle) -> None:
+    actual = _state(scheduler)
+    expected = _oracle_state(oracle, actual["diagnostics"]["algorithm"])
+    # Grid-only retained diagnostics are exact structural evidence, not oracle data.
+    if actual["diagnostics"]["algorithm"] == "sparse_grid":
+        expected["diagnostics"].update(
+            {
+                "posting_count": actual["diagnostics"]["posting_count"],
+                "occupied_cell_count": actual["diagnostics"]["occupied_cell_count"],
+                "estimated_memory_bytes": actual["diagnostics"][
+                    "estimated_memory_bytes"
+                ],
+            }
+        )
+    if actual != expected:
+        raise AssertionError("real scheduler state diverged from independent oracle")
+
+
+def _observed(call: Callable[[], Any]) -> dict[str, Any]:
+    try:
+        value = call()
+        if isinstance(value, SpectrumReservation):
+            result: Any = _reservation(value)
+        elif value is None:
+            result = None
+        else:
+            result = {
+                "requested": [list(value.requested.lower), list(value.requested.upper)],
+                "conflicting_ids": list(value.conflicting_ids),
+            }
+        return {"result": result}
+    except Exception as error:  # noqa: BLE001 - exact exception is experiment evidence
+        detail: dict[str, Any] = {
+            "module": type(error).__module__,
+            "type": type(error).__qualname__,
+            "message": str(error),
+        }
+        if isinstance(error, SpectrumConflictError):
+            detail["conflicting_ids"] = list(error.conflict.conflicting_ids)
+        return {"exception": detail}
+
+
+def _semantic_trace(kind: str) -> dict[str, Any]:
+    scheduler = _new_scheduler(
+        kind, active_entries=4, blocks=MINIMUM_BLOCKS, scenario_count=4
+    )
+    oracle = _RadioOracle(CHANNEL_COUNT)
+    arguments: dict[str, Any] = {
+        "owner": "alpha",
+        "channel_start": 5,
+        "channel_width": 2,
+        "start": 10,
+        "end": 20,
+        "guard_channels": 1,
+        "request_id": "packet",
+    }
+    first = scheduler.reserve(**arguments)
+    expected_first = oracle.reserve(**arguments)
+    replay = scheduler.reserve(**arguments)
+    expected_replay = oracle.reserve(**arguments)
+    calls = [
+        {"name": "reserve", **_observed(lambda: first)},
+        {
+            "name": "idempotent-replay",
+            "same_identity": replay is first,
+            **_observed(lambda: replay),
+        },
+        {
+            "name": "idempotency-mismatch",
+            **_observed(lambda: scheduler.reserve(**{**arguments, "end": 21})),
+        },
+        {
+            "name": "conflicting-reserve",
+            **_observed(
+                lambda: scheduler.reserve("beta", 8, 1, 12, 14, guard_channels=1)
+            ),
+        },
+        {
+            "name": "conflicts-for",
+            **_observed(lambda: scheduler.conflicts_for(5, 2, 12, 14)),
+        },
+    ]
+    oracle_mismatch = _observed(lambda: oracle.reserve(**{**arguments, "end": 21}))
+    oracle_conflict = _observed(
+        lambda: oracle.reserve("beta", 8, 1, 12, 14, guard_channels=1)
+    )
+    oracle_query_raw = oracle.conflicts_for(5, 2, 12, 14)
+    if oracle_query_raw is None:
+        raise AssertionError("oracle query unexpectedly had no conflict")
+    touching = scheduler.reserve("gamma", 5, 2, 20, 25, guard_channels=1)
+    oracle_touching = oracle.reserve("gamma", 5, 2, 20, 25, guard_channels=1)
+    cancelled = scheduler.cancel("alpha", first.id)
+    oracle_cancelled = oracle.cancel("alpha", expected_first.id)
+    cancelled_again = scheduler.cancel("alpha", first.id)
+    oracle_cancelled_again = oracle.cancel("alpha", expected_first.id)
+    replacement = scheduler.reserve("delta", 5, 2, 10, 20, guard_channels=1)
+    oracle_replacement = oracle.reserve("delta", 5, 2, 10, 20, guard_channels=1)
+    calls.extend(
+        [
+            {"name": "touching-time", **_observed(lambda: touching)},
+            {"name": "cancel", **_observed(lambda: cancelled)},
+            {
+                "name": "cancel-idempotent",
+                "same_identity": cancelled_again is cancelled,
+                **_observed(lambda: cancelled_again),
+            },
+            {"name": "historical-duplicate-geometry", **_observed(lambda: replacement)},
+            {
+                "name": "wrong-owner",
+                **_observed(lambda: scheduler.cancel("wrong", replacement.id)),
+            },
+            {
+                "name": "missing",
+                **_observed(lambda: scheduler.cancel("delta", "missing")),
+            },
+        ]
+    )
+    expected_calls = [
+        {"name": "reserve", **_observed(lambda: expected_first)},
+        {
+            "name": "idempotent-replay",
+            "same_identity": expected_replay is expected_first,
+            **_observed(lambda: expected_replay),
+        },
+        {"name": "idempotency-mismatch", **oracle_mismatch},
+        {"name": "conflicting-reserve", **oracle_conflict},
+        {
+            "name": "conflicts-for",
+            "result": {
+                "requested": [
+                    list(oracle_query_raw[0].lower),
+                    list(oracle_query_raw[0].upper),
+                ],
+                "conflicting_ids": list(oracle_query_raw[1]),
+            },
+        },
+        {"name": "touching-time", **_observed(lambda: oracle_touching)},
+        {"name": "cancel", **_observed(lambda: oracle_cancelled)},
+        {
+            "name": "cancel-idempotent",
+            "same_identity": oracle_cancelled_again is oracle_cancelled,
+            **_observed(lambda: oracle_cancelled_again),
+        },
+        {
+            "name": "historical-duplicate-geometry",
+            **_observed(lambda: oracle_replacement),
+        },
+        {
+            "name": "wrong-owner",
+            **_observed(lambda: oracle.cancel("wrong", oracle_replacement.id)),
+        },
+        {
+            "name": "missing",
+            **_observed(lambda: oracle.cancel("delta", "missing")),
+        },
+    ]
+    if calls != expected_calls:
+        raise AssertionError("scheduler calls diverged from independent radio oracle")
+    _assert_state(scheduler, oracle)
+    state = _state(scheduler)
+    return {
+        "kind": kind,
+        "algorithm": state["diagnostics"]["algorithm"],
+        "calls": calls,
+        "snapshot_order": [item["id"] for item in state["reservations"]],
+        "snapshot_version": state["geometry"]["version"],
+        "final_state": state,
+        "final_state_sha256": _sha(state),
+    }
+
+
+def _grid_guard_adversary() -> dict[str, Any]:
+    scheduler = RadioSpectrumScheduler(CHANNEL_COUNT)
+    setattr(
+        scheduler,
+        "_index",
+        BoundedBoxIndex(
+            Box((0, 0), (CHANNEL_COUNT, 1_024)),
+            (4, 8),
+            max_total_cells=2_048,
+            max_cells_per_entry=4,
+            max_cells_per_query=64,
+            max_total_postings=128,
+            max_estimated_bytes=2 * 1024 * 1024,
+        ),
+    )
+    scheduler.reserve("guard", 0, 1, 0, 2)
+    before = _state(scheduler)
+    try:
+        scheduler.conflicts_for(0, CHANNEL_COUNT, 0, 1_024)
+    except ValueError as error:
+        observed = {
+            "module": type(error).__module__,
+            "type": type(error).__qualname__,
+            "message": str(error),
+        }
+    else:
+        raise AssertionError("grid guard error was swallowed or fell back")
+    after = _state(scheduler)
+    if before != after or "max_cells_per_query" not in observed["message"]:
+        raise AssertionError("grid guard did not propagate atomically")
+    return {
+        "algorithm": scheduler._index.diagnostics().algorithm,
+        "bounds": [[0, 0], [CHANNEL_COUNT, 1_024]],
+        "cell_size": [4, 8],
+        "limits": {
+            "max_total_cells": 2_048,
+            "max_cells_per_entry": 4,
+            "max_cells_per_query": 64,
+            "max_total_postings": 128,
+            "max_estimated_bytes": 2 * 1024 * 1024,
+        },
+        "error": observed,
+        "state_unchanged": True,
+        "fallback": None,
+    }
+
+
+def _query_arguments(
+    scenario: Scenario, active_entries: int, query_index: int
+) -> tuple[int, int, int, int]:
+    seed = _seed_arguments(scenario, query_index % active_entries)
+    channel_start = int(seed["channel_start"])
+    channel_width = int(seed["channel_width"])
+    start = int(seed["start"])
+    end = int(seed["end"])
+    padding = {"low": 0, "medium": 1, "high": 2}[scenario.density]
+    if padding:
+        channel_start = max(0, channel_start - padding)
+        channel_end = min(CHANNEL_COUNT, channel_start + channel_width + 2 * padding)
+        channel_width = channel_end - channel_start
+        start = max(0, start - padding)
+        end += padding
+    if scenario.channel_query == "broad":
+        channel_start, channel_width = 0, CHANNEL_COUNT
+    if scenario.time_query == "broad":
+        last = _seed_arguments(scenario, active_entries - 1)
+        start, end = 0, int(last["end"])
+    return channel_start, channel_width, start, end
+
+
+_Command = tuple[str, tuple[Any, ...], dict[str, Any]]
+
+
+def _mutation_arguments(
+    scenario: Scenario,
+    *,
+    active_entries: int,
+    scenario_index: int,
+    block_index: int,
+    total_blocks: int,
+    seed: int,
+    slot: int,
+) -> tuple[tuple[Any, ...], dict[str, Any], str]:
+    last_seed = _seed_arguments(scenario, active_entries - 1)
+    start = (
+        int(last_seed["end"]) + 8 + (scenario_index * total_blocks + block_index) * 8
+    )
+    owner = f"timed-{seed}-{scenario.name}-{block_index}-{slot}"
+    args = (owner, (block_index * 7 + slot) % CHANNEL_COUNT, 1, start, start + 2)
+    kwargs = {"request_id": f"request-{block_index}-{slot}"}
+    return args, kwargs, f"{owner}:1"
+
+
+def _commands(
+    scenario: Scenario,
+    *,
+    active_entries: int,
+    scenario_index: int,
+    block_index: int,
+    total_blocks: int,
+    seed: int,
+) -> tuple[tuple[_Command, ...], tuple[_Command, ...]]:
+    rng = random.Random(seed + scenario_index * 100_003 + block_index)
+    timed: list[_Command] = []
+    setup: list[_Command] = []
+    for _ in range(4):
+        args = _query_arguments(scenario, active_entries, rng.randrange(active_entries))
+        timed.append(("conflicts_for", args, {}))
+
+    mutations = [
+        _mutation_arguments(
+            scenario,
+            active_entries=active_entries,
+            scenario_index=scenario_index,
+            block_index=block_index,
+            total_blocks=total_blocks,
+            seed=seed,
+            slot=slot,
+        )
+        for slot in range(4)
+    ]
+    ratio = scenario.insertion_cancellation_ratio
+    if ratio == "3:1":
+        timed.extend(("reserve", args, kwargs) for args, kwargs, _ in mutations[:3])
+        timed.append(("cancel", (mutations[0][0][0], mutations[0][2]), {}))
+    elif ratio == "2:2":
+        timed.extend(("reserve", args, kwargs) for args, kwargs, _ in mutations[:2])
+        timed.extend(
+            ("cancel", (args[0], reservation_id), {})
+            for args, _, reservation_id in mutations[:2]
+        )
+    elif ratio == "1:3":
+        setup.extend(("reserve", args, kwargs) for args, kwargs, _ in mutations[:3])
+        timed.append(("reserve", mutations[3][0], mutations[3][1]))
+        timed.extend(
+            ("cancel", (args[0], reservation_id), {})
+            for args, _, reservation_id in mutations[:3]
+        )
+    else:
+        setup.append(("reserve", mutations[0][0], mutations[0][1]))
+        timed.extend(("reserve", mutations[0][0], mutations[0][1]) for _ in range(4))
+
+    if len(timed) != OPERATIONS_PER_POSITION:
+        raise AssertionError("timed position operation count changed")
+    return tuple(setup), tuple(timed)
+
+
+def _execute(target: Any, commands: Sequence[_Command]) -> tuple[Any, ...]:
+    results: list[Any] = []
+    for method, args, kwargs in commands:
+        value = getattr(target, method)(*args, **kwargs)
+        if method == "conflicts_for":
+            if value is None:
+                results.append(None)
+            elif isinstance(value, tuple):
+                results.append((value[0], tuple(value[1])))
+            else:
+                results.append((value.requested, value.conflicting_ids))
+        else:
+            results.append(value)
+    return tuple(results)
+
+
+def _normalize_results(values: Sequence[Any]) -> list[Any]:
+    normalized: list[Any] = []
+    for value in values:
+        if value is None:
+            normalized.append(None)
+        elif isinstance(value, SpectrumReservation):
+            normalized.append(_reservation(value))
+        else:
+            normalized.append(
+                {
+                    "requested": [list(value[0].lower), list(value[0].upper)],
+                    "ids": list(value[1]),
+                }
+            )
+    return normalized
+
+
+def _candidate_count(index: Any, box: Box) -> int:
+    with index._lock:
+        state = index._state
+        return len(
+            index._strategy.candidate_handles(state.strategy_state, box, state.entries)
+        )
+
+
+def _query_diagnostics(
+    scheduler: RadioSpectrumScheduler,
+    scenario: Scenario,
+    active_entries: int,
+    seed: int,
+) -> dict[str, Any]:
+    candidates = []
+    matches = []
+    for query in range(16):
+        args = _query_arguments(
+            scenario,
+            active_entries,
+            random.Random(seed + query).randrange(active_entries),
+        )
+        box = Box((args[0], args[2]), (args[0] + args[1], args[3]))
+        candidates.append(_candidate_count(scheduler._index, box))
+        matches.append(len(scheduler._index.overlaps(box)))
+    diagnostics = scheduler._index.diagnostics()
+    return {
+        "samples": len(candidates),
+        "candidate_counts": candidates,
+        "candidate_median": float(statistics.median(candidates)),
+        "candidate_max": max(candidates),
+        "match_counts": matches,
+        "match_median": float(statistics.median(matches)),
+        "match_max": max(matches),
+        "posting_count": diagnostics.posting_count,
+        "algorithm": diagnostics.algorithm,
+    }
+
+
+def _bootstrap(values: Sequence[float], seed: int) -> dict[str, float]:
+    if not values:
+        raise ValueError("cannot summarize empty samples")
+    rng = random.Random(seed)
+    medians = sorted(
+        statistics.median(rng.choices(values, k=len(values)))
+        for _ in range(BOOTSTRAP_RESAMPLES)
+    )
+    return {
+        "median": float(statistics.median(values)),
+        "median_95_low": float(medians[int(0.025 * len(medians))]),
+        "median_95_high": float(medians[int(0.975 * len(medians))]),
+    }
+
+
+def _normalized_state(state: dict[str, Any]) -> dict[str, Any]:
+    result = json.loads(json.dumps(state, allow_nan=False))
+    result["diagnostics"].update(
+        {
+            "algorithm": "normalized",
+            "projection_sizes": [],
+            "posting_count": None,
+            "occupied_cell_count": None,
+            "estimated_memory_bytes": None,
+        }
+    )
+    return result
+
+
+def _measure_scenario(
+    candidate_scheduler: RadioSpectrumScheduler,
+    baseline_scheduler: RadioSpectrumScheduler,
+    candidate_oracle: _RadioOracle,
+    baseline_oracle: _RadioOracle,
+    *,
+    phase: str,
+    candidate: str,
+    scenario: Scenario,
+    scenario_index: int,
+    active_entries: int,
+    blocks: int,
+    seed: int,
+) -> dict[str, Any]:
+    raw_blocks = []
+    ratios = []
+    candidate_ns_values: list[int] = []
+    baseline_ns_values: list[int] = []
+    for block_index in range(blocks):
+        setup, commands = _commands(
+            scenario,
+            active_entries=active_entries,
+            scenario_index=scenario_index,
+            block_index=block_index,
+            total_blocks=blocks,
+            seed=seed,
+        )
+        setup_expected = _normalize_results(_execute(candidate_oracle, setup))
+        if _normalize_results(_execute(baseline_oracle, setup)) != setup_expected:
+            raise AssertionError("independent oracle setup instances diverged")
+        if (
+            _normalize_results(_execute(candidate_scheduler, setup)) != setup_expected
+            or _normalize_results(_execute(baseline_scheduler, setup)) != setup_expected
+        ):
+            raise AssertionError("untimed mutation setup diverged from oracle")
+        oracle_results = _execute(candidate_oracle, commands)
+        other_oracle_results = _execute(baseline_oracle, commands)
+        if _normalize_results(oracle_results) != _normalize_results(
+            other_oracle_results
+        ):
+            raise AssertionError("independent oracle instances diverged")
+        order = (
+            ("candidate", candidate_scheduler, candidate_ns_values)
+            if block_index % 2 == 0
+            else ("baseline", baseline_scheduler, baseline_ns_values)
+        )
+        second = (
+            ("baseline", baseline_scheduler, baseline_ns_values)
+            if block_index % 2 == 0
+            else ("candidate", candidate_scheduler, candidate_ns_values)
+        )
+        durations: dict[str, int] = {}
+        results: dict[str, tuple[Any, ...]] = {}
+        for label, scheduler, sink in (order, second):
+            started = time.perf_counter_ns()
+            result = _execute(scheduler, commands)
+            duration = time.perf_counter_ns() - started
+            durations[label] = duration
+            results[label] = result
+            sink.append(duration)
+        expected = _normalize_results(oracle_results)
+        if (
+            _normalize_results(results["candidate"]) != expected
+            or _normalize_results(results["baseline"]) != expected
+        ):
+            raise AssertionError("timed scheduler result diverged from oracle")
+        # Exact same timed instances are validated only after both timers stop.
+        _assert_state(candidate_scheduler, candidate_oracle)
+        _assert_state(baseline_scheduler, baseline_oracle)
+        candidate_state = _normalized_state(_state(candidate_scheduler))
+        baseline_state = _normalized_state(_state(baseline_scheduler))
+        if candidate_state != baseline_state:
+            raise AssertionError("candidate and linear scheduler final states diverged")
+        ratio = durations["candidate"] / durations["baseline"]
+        ratios.append(ratio)
+        raw_blocks.append(
+            {
+                "block": block_index,
+                "order": [order[0], second[0]],
+                "operations": len(commands),
+                "candidate_ns": durations["candidate"],
+                "baseline_ns": durations["baseline"],
+                "ratio": ratio,
+            }
+        )
+    digest_state = _normalized_state(_state(candidate_scheduler))
+    return {
+        "phase": phase,
+        "candidate": candidate,
+        "scenario": dataclasses.asdict(scenario),
+        "active_entries": active_entries,
+        "seed": seed,
+        "blocks": raw_blocks,
+        "ratios": ratios,
+        "ratio": _bootstrap(ratios, BOOTSTRAP_SEED + seed + active_entries),
+        "candidate_latency_ns": _bootstrap(
+            [float(value) for value in candidate_ns_values],
+            BOOTSTRAP_SEED + seed + active_entries + 1,
+        ),
+        "baseline_latency_ns": _bootstrap(
+            [float(value) for value in baseline_ns_values],
+            BOOTSTRAP_SEED + seed + active_entries + 2,
+        ),
+        "operations_per_position": OPERATIONS_PER_POSITION,
+        "validated_blocks": blocks,
+        "query_diagnostics": _query_diagnostics(
+            candidate_scheduler, scenario, active_entries, seed
+        ),
+        "final_state_sha256": _sha(digest_state),
+    }
+
+
+def _measure_phase(
+    *,
+    phase: str,
+    sizes: Sequence[int],
+    scenarios: Sequence[Scenario],
+    candidates: Sequence[str],
+    blocks: int,
+    seed: int,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    construction = []
+    rows = []
+    for candidate in candidates:
+        for active_entries in sizes:
+            for scenario_index, scenario in enumerate(scenarios):
+                baseline, baseline_oracle, baseline_metrics = _construct(
+                    "linear",
+                    active_entries=active_entries,
+                    blocks=blocks,
+                    scenario_count=len(scenarios),
+                    scenario=scenario,
+                )
+                tested, tested_oracle, tested_metrics = _construct(
+                    candidate,
+                    active_entries=active_entries,
+                    blocks=blocks,
+                    scenario_count=len(scenarios),
+                    scenario=scenario,
+                )
+                retained_ratio = int(tested_metrics["retained_bytes"]) / int(
+                    baseline_metrics["retained_bytes"]
+                )
+                construction.append(
+                    {
+                        "phase": phase,
+                        "candidate": candidate,
+                        "scenario": dataclasses.asdict(scenario),
+                        "active_entries": active_entries,
+                        "baseline": baseline_metrics,
+                        "candidate_metrics": tested_metrics,
+                        "retained_memory_ratio": retained_ratio,
+                    }
+                )
+                rows.append(
+                    _measure_scenario(
+                        tested,
+                        baseline,
+                        tested_oracle,
+                        baseline_oracle,
+                        phase=phase,
+                        candidate=candidate,
+                        scenario=scenario,
+                        scenario_index=scenario_index,
+                        active_entries=active_entries,
+                        blocks=blocks,
+                        seed=seed,
+                    )
+                )
+    return construction, rows
+
+
+def _measure_default_linear_control(blocks: int) -> dict[str, Any]:
+    """Measure the untouched constructor against an explicitly injected linear index."""
+    scenario = SCENARIOS[0]
+    default = RadioSpectrumScheduler(CHANNEL_COUNT)
+    default_oracle = _seed_scheduler(default, DEFAULT_LINEAR_CONTROL_SIZE, scenario)
+    control = _new_scheduler(
+        "linear",
+        active_entries=DEFAULT_LINEAR_CONTROL_SIZE,
+        blocks=blocks,
+        scenario_count=len(SCENARIOS),
+    )
+    control_oracle = _seed_scheduler(control, DEFAULT_LINEAR_CONTROL_SIZE, scenario)
+    return _measure_scenario(
+        default,
+        control,
+        default_oracle,
+        control_oracle,
+        phase="default_linear_control",
+        candidate="default",
+        scenario=scenario,
+        scenario_index=0,
+        active_entries=DEFAULT_LINEAR_CONTROL_SIZE,
+        blocks=blocks,
+        seed=DEFAULT_LINEAR_CONTROL_SEED,
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class DecisionEvidence:
+    """Immutable experiment decision; it is not a runtime selection object."""
+
+    policy_version: str
+    decision: str
+    runtime_index: str
+    runtime_seam_retained: bool
+    live_migration: bool
+    selected_cells: tuple[str, ...]
+    rejected_reasons: tuple[str, ...]
+    default_linear_upper_ratio: float
+
+
+def _cell_id(row: dict[str, Any]) -> str:
+    return f"{row['candidate']}:{row['scenario']['name']}:{row['active_entries']}"
+
+
+def _gate(
+    training: Sequence[dict[str, Any]],
+    held_out: Sequence[dict[str, Any]],
+    construction: Sequence[dict[str, Any]],
+    training_sizes: Sequence[int],
+    default_linear_control: dict[str, Any],
+) -> dict[str, Any]:
+    memory = {
+        (
+            row["phase"],
+            row["candidate"],
+            row["scenario"]["name"],
+            row["active_entries"],
+        ): row["retained_memory_ratio"]
+        for row in construction
+    }
+    eligible: dict[tuple[str, str], int] = {}
+    reasons = []
+    for candidate in sorted({row["candidate"] for row in training}):
+        for scenario in sorted({row["scenario"]["name"] for row in training}):
+            by_size = {
+                row["active_entries"]: row
+                for row in training
+                if row["candidate"] == candidate and row["scenario"]["name"] == scenario
+            }
+            crossover = None
+            for left, right in zip(training_sizes, training_sizes[1:], strict=False):
+                if (
+                    left in by_size
+                    and right in by_size
+                    and by_size[left]["ratio"]["median_95_high"]
+                    <= PROJECTION_ELIGIBILITY_LIMIT
+                    and by_size[right]["ratio"]["median_95_high"]
+                    <= PROJECTION_ELIGIBILITY_LIMIT
+                ):
+                    # The crossover is the lower member of the first passing
+                    # adjacent pair, not the first size after that boundary.
+                    crossover = left
+                    break
+            if crossover is None:
+                reasons.append(
+                    f"{candidate}/{scenario}: no adjacent training sizes have upper-95 <= {PROJECTION_ELIGIBILITY_LIMIT:.2f}"
+                )
+            else:
+                eligible[(candidate, scenario)] = crossover
+    selected_training = []
+    for row in training:
+        key = (row["candidate"], row["scenario"]["name"])
+        if (
+            key in eligible
+            and row["active_entries"] >= eligible[key]
+            and row["ratio"]["median_95_high"] <= SELECTED_CELL_LIMIT
+            and memory[
+                (
+                    "training",
+                    row["candidate"],
+                    row["scenario"]["name"],
+                    row["active_entries"],
+                )
+            ]
+            <= MEMORY_LIMIT
+        ):
+            selected_training.append(row)
+    selected_held_out = []
+    held_out_failures = []
+    missing_held_out = []
+    selected_keys = {
+        (row["candidate"], row["scenario"]["name"]) for row in selected_training
+    }
+    for key in sorted(selected_keys):
+        evidence = [
+            row
+            for row in held_out
+            if (row["candidate"], row["scenario"]["name"]) == key
+            and row["active_entries"] >= eligible[key]
+        ]
+        if not evidence:
+            missing_held_out.append(f"{key[0]}/{key[1]}@>={eligible[key]}")
+            continue
+        for row in evidence:
+            memory_ok = (
+                memory[
+                    (
+                        "held_out",
+                        row["candidate"],
+                        row["scenario"]["name"],
+                        row["active_entries"],
+                    )
+                ]
+                <= MEMORY_LIMIT
+            )
+            latency_ok = row["ratio"]["median_95_high"] <= HELD_OUT_SELECTED_LIMIT
+            if memory_ok and latency_ok:
+                selected_held_out.append(row)
+            else:
+                held_out_failures.append(_cell_id(row))
+    if eligible and not selected_training:
+        reasons.append(
+            "eligible latency cells all failed the 1.25x retained-memory gate"
+        )
+    if missing_held_out:
+        reasons.append(
+            "selected crossovers lack predetermined held-out evidence: "
+            + ", ".join(missing_held_out)
+        )
+    if held_out_failures:
+        reasons.append(
+            "held-out selected cells failed latency or memory: "
+            + ", ".join(sorted(held_out_failures))
+        )
+    default_linear_upper = default_linear_control["ratio"]["median_95_high"]
+    if default_linear_upper > DEFAULT_LINEAR_LIMIT:
+        reasons.append(
+            "measured default scheduler exceeded explicitly patched linear control: "
+            f"upper-95 {default_linear_upper:.4f} > {DEFAULT_LINEAR_LIMIT:.2f}"
+        )
+    selected = tuple(
+        sorted(_cell_id(row) for row in [*selected_training, *selected_held_out])
+    )
+    qualifies = (
+        bool(selected_training)
+        and not held_out_failures
+        and not missing_held_out
+        and default_linear_upper <= DEFAULT_LINEAR_LIMIT
+    )
+    if not qualifies and not reasons:
+        reasons.append("no stable crossover passed all fixed gates")
+    decision = DecisionEvidence(
+        policy_version=POLICY_VERSION,
+        decision="QUALIFIED_PRIVATE_CONFIRMATION_REQUIRED" if qualifies else "REJECTED",
+        runtime_index="linear",
+        runtime_seam_retained=False,
+        live_migration=False,
+        selected_cells=selected if qualifies else (),
+        rejected_reasons=tuple(reasons),
+        default_linear_upper_ratio=default_linear_upper,
+    )
+    material = dataclasses.asdict(decision)
+    material["selected_cells"] = list(decision.selected_cells)
+    material["rejected_reasons"] = list(decision.rejected_reasons)
+    return material
+
+
+def _sha(value: Any) -> str:
+    encoded = json.dumps(
+        value, sort_keys=True, separators=(",", ":"), allow_nan=False
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _file(path: Path) -> dict[str, str]:
+    resolved = path.resolve()
+    try:
+        shown = str(resolved.relative_to(_REPOSITORY_ROOT))
+    except ValueError:
+        shown = str(resolved)
+    return {"path": shown, "sha256": hashlib.sha256(resolved.read_bytes()).hexdigest()}
+
+
+def _git_metadata() -> dict[str, Any]:
+    def git(*args: str) -> str:
+        return subprocess.run(
+            ["git", *args],
+            cwd=_REPOSITORY_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+
+    status = git("status", "--porcelain=v1", "--untracked-files=all")
+    changed = sorted(line[3:] for line in status.splitlines() if len(line) >= 4)
+    staged = sorted(
+        path for path in git("diff", "--cached", "--name-only").splitlines() if path
+    )
+    digest = hashlib.sha256(git("rev-parse", "HEAD").strip().encode())
+    for relative in changed:
+        path = _REPOSITORY_ROOT / relative
+        digest.update(relative.encode())
+        digest.update(b"\0")
+        if path.is_file():
+            digest.update(hashlib.sha256(path.read_bytes()).digest())
+    return {
+        "commit": git("rev-parse", "HEAD").strip(),
+        "head_tree": git("rev-parse", "HEAD^{tree}").strip(),
+        "clean_worktree": not bool(status),
+        "changed_paths": changed,
+        "staged_files": staged,
+        "source_state_sha256": digest.hexdigest(),
+    }
+
+
+def _backend_provenance() -> list[dict[str, Any]]:
+    result = []
+    for name, implementation in (
+        ("linear", BoxIndex),
+        ("projection", BoxIndex2D),
+        ("grid", BoundedBoxIndex),
+    ):
+        result.append(
+            {
+                "id": name,
+                "module": implementation.__module__,
+                "type": implementation.__qualname__,
+                "source": _file(Path(inspect.getfile(implementation))),
+            }
+        )
+    return result
+
+
+def _provenance() -> dict[str, Any]:
+    return {
+        "git": _git_metadata(),
+        "sources": [_file(_REPOSITORY_ROOT / path) for path in _SOURCE_PATHS],
+        "runtime": {
+            "python_version": platform.python_version(),
+            "python_implementation": platform.python_implementation(),
+            "python_compiler": platform.python_compiler(),
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "executable": sys.executable,
+        },
+        "build": {
+            "command": os.environ.get(
+                "TREE_MENDOUS_BUILD_COMMAND", "uv sync --all-extras"
+            ),
+            "flags": {name: os.environ.get(name, "") for name in BUILD_FLAG_NAMES},
+        },
+        "backends": _backend_provenance(),
+    }
+
+
+def _methodology(
+    *,
+    profile: str,
+    blocks: int,
+    training_sizes: Sequence[int],
+    held_out_sizes: Sequence[int],
+    scenarios: Sequence[Scenario],
+    candidates: Sequence[str],
+) -> dict[str, Any]:
+    return {
+        "profile": profile,
+        "minimum_blocks": MINIMUM_BLOCKS,
+        "blocks_recorded_before_run": blocks,
+        "training_sizes": list(training_sizes),
+        "held_out_sizes": list(held_out_sizes),
+        "training_seed": 81_337,
+        "held_out_seed": 914_221,
+        "scenarios": [dataclasses.asdict(item) for item in scenarios],
+        "candidates": list(candidates),
+        "default_linear_control": {
+            "active_entries": DEFAULT_LINEAR_CONTROL_SIZE,
+            "scenario": SCENARIOS[0].name,
+            "seed": DEFAULT_LINEAR_CONTROL_SEED,
+            "comparison": "untouched constructor / explicitly injected BoxIndex(2)",
+        },
+        "operations_per_timed_position": OPERATIONS_PER_POSITION,
+        "balanced_order": "fixed AB/BA blocks alternating candidate/linear and linear/candidate",
+        "bootstrap_unit": "whole balanced block",
+        "setup_timing": "scheduler/index construction, seeding, and distinct live cancellation-handle preparation excluded from operation latency",
+        "validation_timing": "exact same timed instances validated against independent oracle after timing",
+        "construction_timing": "real scheduler construction, private empty-index injection, and seed reservations",
+        "memory_method": "recursive retained Python graph bytes plus process RSS high-water delta proxy",
+        "bootstrap_resamples": BOOTSTRAP_RESAMPLES,
+        "bootstrap_seed": BOOTSTRAP_SEED,
+        "fixed_gates": {
+            "adjacent_training_upper_95": PROJECTION_ELIGIBILITY_LIMIT,
+            "selected_training_upper_95": SELECTED_CELL_LIMIT,
+            "selected_held_out_upper_95": HELD_OUT_SELECTED_LIMIT,
+            "default_linear_upper_95": DEFAULT_LINEAR_LIMIT,
+            "selected_retained_memory_ratio": MEMORY_LIMIT,
+        },
+        "live_migration": False,
+    }
+
+
+def run_matrix(
+    *,
+    blocks: int = MINIMUM_BLOCKS,
+    profile: str = "full",
+    training_sizes: Sequence[int] | None = None,
+    held_out_sizes: Sequence[int] | None = None,
+    scenarios: Sequence[Scenario] | None = None,
+    candidates: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Run the fixed full matrix or an explicitly marked focused test profile."""
+    if type(blocks) is not int or blocks < MINIMUM_BLOCKS:
+        raise ValueError(f"blocks must be an integer >= {MINIMUM_BLOCKS}")
+    if profile not in {"full", "focused"}:
+        raise ValueError("profile must be full or focused")
+    training_sizes = tuple(training_sizes or TRAINING_SIZES)
+    held_out_sizes = tuple(held_out_sizes or HELD_OUT_SIZES)
+    scenarios = tuple(scenarios or SCENARIOS)
+    candidates = tuple(candidates or CANDIDATES)
+    if profile == "full" and (
+        training_sizes != TRAINING_SIZES
+        or held_out_sizes != HELD_OUT_SIZES
+        or scenarios != SCENARIOS
+        or candidates != CANDIDATES
+    ):
+        raise ValueError("full profile dimensions are fixed")
+    if (
+        not training_sizes
+        or not held_out_sizes
+        or not scenarios
+        or len(set(training_sizes)) != len(training_sizes)
+        or len(set(held_out_sizes)) != len(held_out_sizes)
+        or len({item.name for item in scenarios}) != len(scenarios)
+        or len(set(candidates)) != len(candidates)
+        or any(candidate not in CANDIDATES for candidate in candidates)
+        or any(item not in SCENARIOS for item in scenarios)
+    ):
+        raise ValueError("matrix dimensions must be nonempty fixed-domain values")
+    methodology = _methodology(
+        profile=profile,
+        blocks=blocks,
+        training_sizes=training_sizes,
+        held_out_sizes=held_out_sizes,
+        scenarios=scenarios,
+        candidates=candidates,
+    )
+    correctness = [_semantic_trace(kind) for kind in ("linear", *candidates)]
+    adversaries = {
+        "broad_query": {
+            "scenario": dataclasses.asdict(
+                next(item for item in SCENARIOS if item.name == "high-broad-both")
+            ),
+            "required_in_training": any(
+                item.name == "high-broad-both" for item in scenarios
+            ),
+        },
+        "grid_guard": _grid_guard_adversary(),
+    }
+    training_construction, training = _measure_phase(
+        phase="training",
+        sizes=training_sizes,
+        scenarios=scenarios,
+        candidates=candidates,
+        blocks=blocks,
+        seed=methodology["training_seed"],
+    )
+    held_construction, held_out = _measure_phase(
+        phase="held_out",
+        sizes=held_out_sizes,
+        scenarios=scenarios,
+        candidates=candidates,
+        blocks=blocks,
+        seed=methodology["held_out_seed"],
+    )
+    construction = [*training_construction, *held_construction]
+    default_linear_control = _measure_default_linear_control(blocks)
+    decision = _gate(
+        training,
+        held_out,
+        construction,
+        training_sizes,
+        default_linear_control,
+    )
+    return {
+        "schema": SCHEMA,
+        "methodology": methodology,
+        "correctness": correctness,
+        "adversaries": adversaries,
+        "construction": construction,
+        "training": training,
+        "held_out": held_out,
+        "default_linear_control": default_linear_control,
+        "decision": decision,
+        "provenance": _provenance(),
+    }
+
+
+def _markdown(report: dict[str, Any], digest: str) -> str:
+    lines = [
+        "# RadioSpectrumScheduler index representation experiment",
+        "",
+        f"Decision: **{report['decision']['decision']}**",
+        f"Retained runtime index: **{report['decision']['runtime_index']}**",
+        f"Runtime seam retained: **{report['decision']['runtime_seam_retained']}**",
+        f"JSON SHA-256: `{digest}`",
+        "",
+        "| phase | candidate | scenario | active | median ratio | upper 95% | candidate median ns | memory ratio |",
+        "| --- | --- | --- | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    memory = {
+        (
+            row["phase"],
+            row["candidate"],
+            row["scenario"]["name"],
+            row["active_entries"],
+        ): row["retained_memory_ratio"]
+        for row in report["construction"]
+    }
+    for row in [*report["training"], *report["held_out"]]:
+        lines.append(
+            f"| {row['phase']} | {row['candidate']} | {row['scenario']['name']} | "
+            f"{row['active_entries']} | {row['ratio']['median']:.4f} | "
+            f"{row['ratio']['median_95_high']:.4f} | "
+            f"{row['candidate_latency_ns']['median']:.0f} | "
+            f"{memory[(row['phase'], row['candidate'], row['scenario']['name'], row['active_entries'])]:.4f} |"
+        )
+    lines.extend(("", "## Rejected reasons", ""))
+    reasons = report["decision"]["rejected_reasons"]
+    lines.extend(f"- {reason}" for reason in reasons)
+    if not reasons:
+        lines.append("- none")
+    return "\n".join(lines) + "\n"
+
+
+def write_artifacts(report: dict[str, Any], output: Path) -> tuple[Path, Path, Path]:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (
+        json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    ).encode()
+    output.write_bytes(encoded)
+    digest = hashlib.sha256(encoded).hexdigest()
+    markdown = output.with_suffix(".md")
+    markdown.write_text(_markdown(report, digest))
+    checksum = Path(f"{output}.sha256")
+    checksum.write_text(f"{digest}  {output.name}\n")
+    return output, markdown, checksum
+
+
+def _duplicates(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate key: {key!r}")
+        result[key] = value
+    return result
+
+
+def _nonfinite(value: str) -> None:
+    raise ValueError(f"non-finite number: {value}")
+
+
+def _finite(value: str) -> float:
+    result = float(value)
+    if not math.isfinite(result):
+        raise ValueError(f"non-finite number: {value}")
+    return result
+
+
+def _exact(left: Any, right: Any) -> bool:
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, dict):
+        return left.keys() == right.keys() and all(
+            _exact(left[key], right[key]) for key in left
+        )
+    if isinstance(left, list):
+        return len(left) == len(right) and all(
+            _exact(a, b) for a, b in zip(left, right, strict=True)
+        )
+    return bool(left == right)
+
+
+def _expected_row_evidence(
+    candidate: str,
+    scenario: Scenario,
+    *,
+    active_entries: int,
+    scenario_index: int,
+    scenario_count: int,
+    blocks: int,
+    seed: int,
+) -> tuple[dict[str, Any], str]:
+    scheduler = (
+        RadioSpectrumScheduler(CHANNEL_COUNT)
+        if candidate == "default"
+        else _new_scheduler(
+            candidate,
+            active_entries=active_entries,
+            blocks=blocks,
+            scenario_count=scenario_count,
+        )
+    )
+    _seed_scheduler(scheduler, active_entries, scenario)
+    for block_index in range(blocks):
+        setup, timed = _commands(
+            scenario,
+            active_entries=active_entries,
+            scenario_index=scenario_index,
+            block_index=block_index,
+            total_blocks=blocks,
+            seed=seed,
+        )
+        _execute(scheduler, setup)
+        _execute(scheduler, timed)
+    return (
+        _query_diagnostics(scheduler, scenario, active_entries, seed),
+        _sha(_normalized_state(_state(scheduler))),
+    )
+
+
+def _verify_row(
+    row: Any,
+    blocks: int,
+    *,
+    phase: str,
+    candidate: str,
+    scenario: Scenario,
+    scenario_index: int,
+    scenario_count: int,
+    active_entries: int,
+    seed_value: int,
+) -> None:
+    keys = {
+        "phase",
+        "candidate",
+        "scenario",
+        "active_entries",
+        "seed",
+        "blocks",
+        "ratios",
+        "ratio",
+        "candidate_latency_ns",
+        "baseline_latency_ns",
+        "operations_per_position",
+        "validated_blocks",
+        "query_diagnostics",
+        "final_state_sha256",
+    }
+    if type(row) is not dict or set(row) != keys:
+        raise ValueError("benchmark row schema mismatch")
+    if (
+        row["phase"] != phase
+        or type(row["phase"]) is not str
+        or row["candidate"] != candidate
+        or type(row["candidate"]) is not str
+        or not _exact(row["scenario"], dataclasses.asdict(scenario))
+        or type(row["active_entries"]) is not int
+        or row["active_entries"] != active_entries
+        or type(row["seed"]) is not int
+        or row["seed"] != seed_value
+        or type(row["validated_blocks"]) is not int
+        or row["validated_blocks"] != blocks
+        or type(row["operations_per_position"]) is not int
+        or row["operations_per_position"] != OPERATIONS_PER_POSITION
+    ):
+        raise ValueError("benchmark row exact type/value mismatch")
+    raw = row["blocks"]
+    if type(raw) is not list or len(raw) != blocks:
+        raise ValueError("raw block count mismatch")
+    ratios = []
+    candidate_ns = []
+    baseline_ns = []
+    for index, block in enumerate(raw):
+        if type(block) is not dict or set(block) != {
+            "block",
+            "order",
+            "operations",
+            "candidate_ns",
+            "baseline_ns",
+            "ratio",
+        }:
+            raise ValueError("raw block schema mismatch")
+        expected_order = (
+            ["candidate", "baseline"] if index % 2 == 0 else ["baseline", "candidate"]
+        )
+        if (
+            type(block["block"]) is not int
+            or block["block"] != index
+            or type(block["order"]) is not list
+            or block["order"] != expected_order
+            or type(block["operations"]) is not int
+            or block["operations"] != OPERATIONS_PER_POSITION
+            or type(block["candidate_ns"]) is not int
+            or type(block["baseline_ns"]) is not int
+            or min(block["candidate_ns"], block["baseline_ns"]) <= 0
+            or type(block["ratio"]) is not float
+        ):
+            raise ValueError("raw block exact type/value mismatch")
+        ratio = block["candidate_ns"] / block["baseline_ns"]
+        if block["ratio"] != ratio:
+            raise ValueError("raw ratio mismatch")
+        ratios.append(ratio)
+        candidate_ns.append(float(block["candidate_ns"]))
+        baseline_ns.append(float(block["baseline_ns"]))
+    bootstrap_seed = BOOTSTRAP_SEED + seed_value + active_entries
+    if not _exact(row["ratios"], ratios) or not _exact(
+        row["ratio"], _bootstrap(ratios, bootstrap_seed)
+    ):
+        raise ValueError("derived ratio interval mismatch")
+    if not _exact(
+        row["candidate_latency_ns"], _bootstrap(candidate_ns, bootstrap_seed + 1)
+    ):
+        raise ValueError("derived candidate latency mismatch")
+    if not _exact(
+        row["baseline_latency_ns"], _bootstrap(baseline_ns, bootstrap_seed + 2)
+    ):
+        raise ValueError("derived baseline latency mismatch")
+
+    diagnostics = row["query_diagnostics"]
+    diagnostic_keys = {
+        "samples",
+        "candidate_counts",
+        "candidate_median",
+        "candidate_max",
+        "match_counts",
+        "match_median",
+        "match_max",
+        "posting_count",
+        "algorithm",
+    }
+    expected_algorithm = {
+        "default": "linear",
+        "projection": "axis_projection",
+        "grid": "sparse_grid",
+    }[candidate]
+    if type(diagnostics) is not dict or set(diagnostics) != diagnostic_keys:
+        raise ValueError("query diagnostics schema mismatch")
+    candidate_counts = diagnostics["candidate_counts"]
+    match_counts = diagnostics["match_counts"]
+    if (
+        type(diagnostics["samples"]) is not int
+        or diagnostics["samples"] != 16
+        or type(candidate_counts) is not list
+        or type(match_counts) is not list
+        or len(candidate_counts) != 16
+        or len(match_counts) != 16
+        or any(type(item) is not int or item < 0 for item in candidate_counts)
+        or any(type(item) is not int or item < 0 for item in match_counts)
+        or any(
+            match > possible
+            for match, possible in zip(match_counts, candidate_counts, strict=True)
+        )
+        or type(diagnostics["candidate_median"]) is not float
+        or diagnostics["candidate_median"] != float(statistics.median(candidate_counts))
+        or type(diagnostics["candidate_max"]) is not int
+        or diagnostics["candidate_max"] != max(candidate_counts)
+        or type(diagnostics["match_median"]) is not float
+        or diagnostics["match_median"] != float(statistics.median(match_counts))
+        or type(diagnostics["match_max"]) is not int
+        or diagnostics["match_max"] != max(match_counts)
+        or type(diagnostics["algorithm"]) is not str
+        or diagnostics["algorithm"] != expected_algorithm
+        or (candidate != "grid" and diagnostics["posting_count"] is not None)
+        or (
+            candidate == "grid"
+            and (
+                type(diagnostics["posting_count"]) is not int
+                or diagnostics["posting_count"] < 0
+            )
+        )
+    ):
+        raise ValueError("query diagnostics exact/derived mismatch")
+
+    expected_diagnostics, expected_digest = _expected_row_evidence(
+        candidate,
+        scenario,
+        active_entries=active_entries,
+        scenario_index=scenario_index,
+        scenario_count=scenario_count,
+        blocks=blocks,
+        seed=seed_value,
+    )
+    if not _exact(diagnostics, expected_diagnostics):
+        raise ValueError("reconstructed query diagnostics mismatch")
+    if (
+        type(row["final_state_sha256"]) is not str
+        or row["final_state_sha256"] != expected_digest
+    ):
+        raise ValueError("final state digest mismatch")
+
+
+def verify_artifacts(output: Path) -> dict[str, Any]:
+    """Strictly parse, type-check, and recompute the canonical artifact triplet."""
+    encoded = output.read_bytes()
+    digest = hashlib.sha256(encoded).hexdigest()
+    if Path(f"{output}.sha256").read_text() != f"{digest}  {output.name}\n":
+        raise ValueError("checksum mismatch")
+    report = json.loads(
+        encoded,
+        object_pairs_hook=_duplicates,
+        parse_constant=_nonfinite,
+        parse_float=_finite,
+    )
+    top = {
+        "schema",
+        "methodology",
+        "correctness",
+        "adversaries",
+        "construction",
+        "training",
+        "held_out",
+        "default_linear_control",
+        "decision",
+        "provenance",
+    }
+    if type(report) is not dict or set(report) != top or report["schema"] != SCHEMA:
+        raise ValueError("report schema mismatch")
+    methodology = report["methodology"]
+    if type(methodology) is not dict:
+        raise ValueError("methodology schema mismatch")
+    blocks = methodology.get("blocks_recorded_before_run")
+    if type(blocks) is not int or blocks < MINIMUM_BLOCKS:
+        raise ValueError("methodology block exact type/value mismatch")
+    try:
+        scenarios = tuple(Scenario(**item) for item in methodology["scenarios"])
+        training_sizes = methodology["training_sizes"]
+        held_out_sizes = methodology["held_out_sizes"]
+        candidates = methodology["candidates"]
+        expected_methodology = _methodology(
+            profile=methodology["profile"],
+            blocks=blocks,
+            training_sizes=training_sizes,
+            held_out_sizes=held_out_sizes,
+            scenarios=scenarios,
+            candidates=candidates,
+        )
+    except (KeyError, TypeError, ValueError) as error:
+        raise ValueError("fixed methodology mismatch") from error
+    if (
+        not _exact(methodology, expected_methodology)
+        or type(training_sizes) is not list
+        or type(held_out_sizes) is not list
+        or type(candidates) is not list
+        or not training_sizes
+        or not held_out_sizes
+        or not scenarios
+        or any(
+            type(size) is not int or size <= 0
+            for size in [*training_sizes, *held_out_sizes]
+        )
+        or len(set(training_sizes)) != len(training_sizes)
+        or len(set(held_out_sizes)) != len(held_out_sizes)
+        or len(set(candidates)) != len(candidates)
+        or len({scenario.name for scenario in scenarios}) != len(scenarios)
+        or any(candidate not in CANDIDATES for candidate in candidates)
+        or any(scenario not in SCENARIOS for scenario in scenarios)
+        or (
+            methodology["profile"] == "full"
+            and (
+                tuple(training_sizes) != TRAINING_SIZES
+                or tuple(held_out_sizes) != HELD_OUT_SIZES
+                or scenarios != SCENARIOS
+                or tuple(candidates) != CANDIDATES
+            )
+        )
+        or methodology["profile"] not in {"full", "focused"}
+    ):
+        raise ValueError("fixed methodology mismatch")
+
+    def matrix_specs(
+        phase: str, sizes: Sequence[int], seed_value: int
+    ) -> list[tuple[str, str, Scenario, int, int, int]]:
+        return [
+            (phase, candidate, scenario, scenario_index, active_entries, seed_value)
+            for candidate in candidates
+            for active_entries in sizes
+            for scenario_index, scenario in enumerate(scenarios)
+        ]
+
+    training_specs = matrix_specs(
+        "training", training_sizes, methodology["training_seed"]
+    )
+    held_specs = matrix_specs("held_out", held_out_sizes, methodology["held_out_seed"])
+    if (
+        type(report["training"]) is not list
+        or type(report["held_out"]) is not list
+        or len(report["training"]) != len(training_specs)
+        or len(report["held_out"]) != len(held_specs)
+    ):
+        raise ValueError("matrix membership mismatch")
+    for row, spec in zip(report["training"], training_specs, strict=True):
+        phase, candidate, scenario, scenario_index, active_entries, seed_value = spec
+        _verify_row(
+            row,
+            blocks,
+            phase=phase,
+            candidate=candidate,
+            scenario=scenario,
+            scenario_index=scenario_index,
+            scenario_count=len(scenarios),
+            active_entries=active_entries,
+            seed_value=seed_value,
+        )
+    for row, spec in zip(report["held_out"], held_specs, strict=True):
+        phase, candidate, scenario, scenario_index, active_entries, seed_value = spec
+        _verify_row(
+            row,
+            blocks,
+            phase=phase,
+            candidate=candidate,
+            scenario=scenario,
+            scenario_index=scenario_index,
+            scenario_count=len(scenarios),
+            active_entries=active_entries,
+            seed_value=seed_value,
+        )
+    _verify_row(
+        report["default_linear_control"],
+        blocks,
+        phase="default_linear_control",
+        candidate="default",
+        scenario=SCENARIOS[0],
+        scenario_index=0,
+        scenario_count=len(SCENARIOS),
+        active_entries=DEFAULT_LINEAR_CONTROL_SIZE,
+        seed_value=DEFAULT_LINEAR_CONTROL_SEED,
+    )
+
+    construction_specs = [*training_specs, *held_specs]
+    if type(report["construction"]) is not list or len(report["construction"]) != len(
+        construction_specs
+    ):
+        raise ValueError("construction matrix membership mismatch")
+    algorithms = {"projection": "axis_projection", "grid": "sparse_grid"}
+    for row, spec in zip(report["construction"], construction_specs, strict=True):
+        phase, candidate, scenario, _, active_entries, _ = spec
+        if type(row) is not dict or set(row) != {
+            "phase",
+            "candidate",
+            "scenario",
+            "active_entries",
+            "baseline",
+            "candidate_metrics",
+            "retained_memory_ratio",
+        }:
+            raise ValueError("construction schema mismatch")
+        if (
+            row["phase"] != phase
+            or type(row["phase"]) is not str
+            or row["candidate"] != candidate
+            or type(row["candidate"]) is not str
+            or not _exact(row["scenario"], dataclasses.asdict(scenario))
+            or row["active_entries"] != active_entries
+            or type(row["active_entries"]) is not int
+        ):
+            raise ValueError("construction matrix membership mismatch")
+        for metrics, algorithm in (
+            (row["baseline"], "linear"),
+            (row["candidate_metrics"], algorithms[candidate]),
+        ):
+            if type(metrics) is not dict or set(metrics) != {
+                "algorithm",
+                "construction_ns",
+                "retained_bytes",
+                "rss_before_bytes",
+                "rss_after_bytes",
+                "rss_high_water_delta_bytes",
+            }:
+                raise ValueError("construction metrics schema mismatch")
+            if (
+                metrics["algorithm"] != algorithm
+                or type(metrics["algorithm"]) is not str
+                or any(
+                    type(metrics[key]) is not int or metrics[key] < 0
+                    for key in metrics
+                    if key != "algorithm"
+                )
+                or metrics["construction_ns"] <= 0
+                or metrics["retained_bytes"] <= 0
+                or metrics["rss_after_bytes"] < metrics["rss_before_bytes"]
+                or metrics["rss_high_water_delta_bytes"]
+                != metrics["rss_after_bytes"] - metrics["rss_before_bytes"]
+            ):
+                raise ValueError("construction metric exact type/value mismatch")
+        expected_ratio = (
+            row["candidate_metrics"]["retained_bytes"]
+            / row["baseline"]["retained_bytes"]
+        )
+        if (
+            type(row["retained_memory_ratio"]) is not float
+            or row["retained_memory_ratio"] != expected_ratio
+        ):
+            raise ValueError("retained memory ratio mismatch")
+    expected_decision = _gate(
+        report["training"],
+        report["held_out"],
+        report["construction"],
+        methodology["training_sizes"],
+        report["default_linear_control"],
+    )
+    if not _exact(report["decision"], expected_decision):
+        raise ValueError("recomputed decision mismatch")
+    expected_correctness = [
+        _semantic_trace(kind) for kind in ("linear", *methodology["candidates"])
+    ]
+    if not _exact(report["correctness"], expected_correctness):
+        raise ValueError("recomputed correctness mismatch")
+    expected_adversaries = {
+        "broad_query": {
+            "scenario": dataclasses.asdict(
+                next(item for item in SCENARIOS if item.name == "high-broad-both")
+            ),
+            "required_in_training": any(
+                item.name == "high-broad-both" for item in scenarios
+            ),
+        },
+        "grid_guard": _grid_guard_adversary(),
+    }
+    if not _exact(report["adversaries"], expected_adversaries):
+        raise ValueError("recomputed adversary mismatch")
+    if not _exact(report["provenance"], _provenance()):
+        raise ValueError("source/runtime/backend provenance mismatch")
+    if output.with_suffix(".md").read_text() != _markdown(report, digest):
+        raise ValueError("Markdown mismatch")
+    return report
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--blocks", type=int, default=MINIMUM_BLOCKS)
+    parser.add_argument("--profile", choices=("full", "focused"), default="full")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("build/experiments/radio-spectrum-index-matrix.json"),
+    )
+    parser.add_argument("--verify", action="store_true")
+    args = parser.parse_args()
+    if args.verify:
+        report = verify_artifacts(args.output)
+        print(f"verified {args.output}: {report['decision']['decision']}")
+        return
+    kwargs: dict[str, Any] = {}
+    if args.profile == "focused":
+        kwargs = {
+            "training_sizes": TRAINING_SIZES[:2],
+            "held_out_sizes": HELD_OUT_SIZES[:1],
+            "scenarios": SCENARIOS[:1],
+            "candidates": CANDIDATES[:1],
+        }
+    report = run_matrix(blocks=args.blocks, profile=args.profile, **kwargs)
+    paths = write_artifacts(report, args.output)
+    verify_artifacts(args.output)
+    print(f"{report['decision']['decision']}: {', '.join(str(path) for path in paths)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/performance/experiments/rangeset_snapshot_scaling.py
+++ b/tests/performance/experiments/rangeset_snapshot_scaling.py
@@ -1,0 +1,1064 @@
+#!/usr/bin/env python3
+"""Paired scaling evidence for the geometry-only ``RangeSet`` snapshot cache."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import inspect
+import json
+import math
+import os
+import platform
+import random
+import statistics
+import subprocess
+import sysconfig
+import time
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any, TypeVar
+
+from treemendous import IntervalResult, RangeSnapshot, Span, create_range_set
+from treemendous.rangeset import RangeSet
+
+SCHEMA = "treemendous-rangeset-snapshot-scaling-experiment-v2"
+BACKEND = "py_boundary"
+BUILD_FLAG_NAMES = (
+    "BOOST_ROOT",
+    "TREE_MENDOUS_DISABLE_OPTIMIZATIONS",
+    "TREE_MENDOUS_GLIBCXX_DEBUG",
+    "TREE_MENDOUS_LOCAL_NATIVE",
+    "TREE_MENDOUS_SANITIZERS",
+    "TREE_MENDOUS_WITH_ICL",
+)
+MINIMUM_BLOCKS = 30
+CONFIRMATION_BLOCKS = 40
+INTERVAL_COUNTS = (100, 1_000, 10_000)
+UNCHANGED_READS = 16
+PILOT_TARGET_NS = 5_000_000
+PILOT_MIN_ITERATIONS = 2
+PILOT_MAX_ITERATIONS = 64
+BOOTSTRAP_RESAMPLES = 2_000
+BOOTSTRAP_SEED = 91_337
+UNCHANGED_N10000_LIMIT = 0.25
+CACHED_SCALING_LIMIT = 1.50
+WRITE_OBSERVE_LIMIT = 1.10
+BALANCED_BLOCK_METHOD = (
+    "each block contains one cached-first and one uncached-first ordering; "
+    "ordering-pair sequence alternates AB/BA then BA/AB by block; cached and "
+    "uncached elapsed times are totaled across their two block positions before "
+    "one block ratio is computed; bootstrap resampling units are whole blocks"
+)
+PILOT_METHOD = (
+    "outside retained blocks, start at two timed iterations and double one "
+    "common cached/uncached iteration count until both timed positions reach at "
+    "least 5 ms or the deterministic cap of "
+    "64; record every pilot duration and exclude all pilot data from samples "
+    "and gates"
+)
+TIMED_BOUNDARY = (
+    "public cached snapshot versus faithful uncached RangeSnapshot construction; "
+    "pilot, setup, and same-instance validation outside retained-block timing"
+)
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+T = TypeVar("T")
+
+
+def _seed_ranges(backend: str, count: int) -> RangeSet:
+    ranges = create_range_set(
+        (0, count * 3),
+        backend=backend,
+        initially_available=False,
+    )
+    for index in range(count):
+        ranges.add(Span(index * 3, index * 3 + 1))
+    return ranges
+
+
+def _uncached_snapshot(ranges: RangeSet) -> RangeSnapshot:
+    """Faithfully construct the public value while deliberately bypassing reuse."""
+    with ranges._lock:
+        return RangeSnapshot(
+            ranges.intervals(),
+            ranges._total_free,
+            ranges._domain,
+        )
+
+
+def _snapshot_digest(snapshot: RangeSnapshot) -> str:
+    material = {
+        "domain": (
+            None
+            if snapshot.domain is None
+            else [[span.start, span.end] for span in snapshot.domain.spans]
+        ),
+        "intervals": [
+            [interval.start, interval.end, interval.length, interval.data]
+            for interval in snapshot.intervals
+        ],
+        "total_free": snapshot.total_free,
+    }
+    encoded = json.dumps(
+        material, sort_keys=True, separators=(",", ":"), allow_nan=False
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _expected_snapshot_digest(count: int) -> str:
+    material = {
+        "domain": [[0, count * 3]],
+        "intervals": [[index * 3, index * 3 + 1, 1, None] for index in range(count)],
+        "total_free": count,
+    }
+    encoded = json.dumps(
+        material, sort_keys=True, separators=(",", ":"), allow_nan=False
+    ).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _assert_exact_snapshot(
+    snapshot: RangeSnapshot, *, count: int, removed: bool = False
+) -> None:
+    expected_count = count - int(removed)
+    assert type(snapshot) is RangeSnapshot
+    assert len(snapshot.intervals) == expected_count
+    assert snapshot.total_free == expected_count
+    assert snapshot.domain is not None
+    assert snapshot.domain.spans == (Span(0, count * 3),)
+    assert all(type(item) is IntervalResult for item in snapshot.intervals)
+    expected_last = count - 2 if removed else count - 1
+    assert snapshot.intervals[-1] == IntervalResult(
+        expected_last * 3, expected_last * 3 + 1
+    )
+
+
+def _elapsed(call: Callable[[], T]) -> tuple[int, T]:
+    started = time.perf_counter_ns()
+    result = call()
+    return time.perf_counter_ns() - started, result
+
+
+def _cached_burst(ranges: RangeSet, reads: int) -> RangeSnapshot:
+    snapshot = ranges.snapshot()
+    for _ in range(reads - 1):
+        snapshot = ranges.snapshot()
+    return snapshot
+
+
+def _uncached_burst(ranges: RangeSet, reads: int) -> RangeSnapshot:
+    snapshot = _uncached_snapshot(ranges)
+    for _ in range(reads - 1):
+        snapshot = _uncached_snapshot(ranges)
+    return snapshot
+
+
+def _restorative_cycle(
+    ranges: RangeSet, snapshotter: Callable[[RangeSet], RangeSnapshot], count: int
+) -> tuple[Any, RangeSnapshot, Any, RangeSnapshot]:
+    target = Span((count - 1) * 3, (count - 1) * 3 + 1)
+    removed = ranges.discard(target, require_covered=True)
+    after_remove = snapshotter(ranges)
+    restored = ranges.add(target)
+    after_restore = snapshotter(ranges)
+    return removed, after_remove, restored, after_restore
+
+
+def _repeat(call: Callable[[], T], iterations: int) -> T:
+    result = call()
+    for _ in range(iterations - 1):
+        result = call()
+    return result
+
+
+def _bootstrap_interval(values: Sequence[float], seed: int) -> tuple[float, float]:
+    rng = random.Random(seed)
+    medians = sorted(
+        statistics.median(rng.choices(values, k=len(values)))
+        for _ in range(BOOTSTRAP_RESAMPLES)
+    )
+    return medians[int(0.025 * len(medians))], medians[int(0.975 * len(medians))]
+
+
+def _summary(values: Sequence[int | float], seed: int) -> dict[str, float]:
+    floats = [float(value) for value in values]
+    low, high = _bootstrap_interval(floats, seed)
+    return {
+        "median": float(statistics.median(values)),
+        "median_95_low": low,
+        "median_95_high": high,
+    }
+
+
+def _ratio_summary(
+    cached: Sequence[int], uncached: Sequence[int], seed: int
+) -> tuple[list[float], dict[str, float]]:
+    ratios = [
+        candidate / baseline
+        for candidate, baseline in zip(cached, uncached, strict=True)
+    ]
+    low, high = _bootstrap_interval(ratios, seed)
+    return ratios, {
+        "median": float(statistics.median(ratios)),
+        "median_95_low": low,
+        "median_95_high": high,
+    }
+
+
+def _validate_cycle(
+    result: tuple[Any, RangeSnapshot, Any, RangeSnapshot], count: int
+) -> None:
+    removed, after_remove, restored, after_restore = result
+    target = Span((count - 1) * 3, (count - 1) * 3 + 1)
+    assert removed.changed == (target,)
+    assert removed.changed_length == 1 and removed.fully_covered
+    assert restored.changed == (target,)
+    assert restored.changed_length == 1 and not restored.fully_covered
+    _assert_exact_snapshot(after_remove, count=count, removed=True)
+    _assert_exact_snapshot(after_restore, count=count)
+
+
+def _pilot(
+    cached_call: Callable[[], T],
+    uncached_call: Callable[[], T],
+    validate: Callable[[T, T], None],
+) -> tuple[int, dict[str, Any]]:
+    iterations = PILOT_MIN_ITERATIONS
+    measurements: list[dict[str, int]] = []
+    while True:
+        cached_ns, cached_result = _elapsed(lambda: _repeat(cached_call, iterations))
+        uncached_ns, uncached_result = _elapsed(
+            lambda: _repeat(uncached_call, iterations)
+        )
+        validate(cached_result, uncached_result)
+        measurements.append(
+            {
+                "iterations": iterations,
+                "cached_ns": cached_ns,
+                "uncached_ns": uncached_ns,
+            }
+        )
+        if (
+            min(cached_ns, uncached_ns) >= PILOT_TARGET_NS
+            or iterations == PILOT_MAX_ITERATIONS
+        ):
+            break
+        iterations = min(iterations * 2, PILOT_MAX_ITERATIONS)
+    return iterations, {
+        "target_position_ns": PILOT_TARGET_NS,
+        "maximum_iterations": PILOT_MAX_ITERATIONS,
+        "order": "cached_then_uncached",
+        "measurements": measurements,
+        "selected_iterations": iterations,
+        "target_reached_by_both": min(cached_ns, uncached_ns) >= PILOT_TARGET_NS,
+        "excluded_from_blocks_and_gates": True,
+    }
+
+
+def _balanced_blocks(
+    cached_call: Callable[[], T],
+    uncached_call: Callable[[], T],
+    validate: Callable[[T, T], None],
+    *,
+    block_count: int,
+    iterations: int,
+    seed: int,
+) -> tuple[
+    list[dict[str, Any]],
+    list[float],
+    dict[str, float],
+    dict[str, float],
+    dict[str, float],
+]:
+    blocks: list[dict[str, Any]] = []
+    cached_totals: list[int] = []
+    uncached_totals: list[int] = []
+    for block_index in range(block_count):
+        orderings = (
+            ("cached_first", "uncached_first")
+            if block_index % 2 == 0
+            else ("uncached_first", "cached_first")
+        )
+        positions: list[dict[str, Any]] = []
+        for ordering in orderings:
+            if ordering == "cached_first":
+                cached_ns, cached_result = _elapsed(
+                    lambda: _repeat(cached_call, iterations)
+                )
+                uncached_ns, uncached_result = _elapsed(
+                    lambda: _repeat(uncached_call, iterations)
+                )
+            else:
+                uncached_ns, uncached_result = _elapsed(
+                    lambda: _repeat(uncached_call, iterations)
+                )
+                cached_ns, cached_result = _elapsed(
+                    lambda: _repeat(cached_call, iterations)
+                )
+            validate(cached_result, uncached_result)
+            positions.append(
+                {
+                    "ordering": ordering,
+                    "cached_ns": cached_ns,
+                    "uncached_ns": uncached_ns,
+                }
+            )
+        cached_total = sum(position["cached_ns"] for position in positions)
+        uncached_total = sum(position["uncached_ns"] for position in positions)
+        ratio = cached_total / uncached_total
+        blocks.append(
+            {
+                "block_index": block_index,
+                "positions": positions,
+                "cached_ns_total": cached_total,
+                "uncached_ns_total": uncached_total,
+                "ratio": ratio,
+            }
+        )
+        cached_totals.append(cached_total)
+        uncached_totals.append(uncached_total)
+    ratios, ratio_summary = _ratio_summary(cached_totals, uncached_totals, seed)
+    divisor = 2 * iterations
+    cached_per_iteration = [value / divisor for value in cached_totals]
+    uncached_per_iteration = [value / divisor for value in uncached_totals]
+    return (
+        blocks,
+        ratios,
+        _summary(cached_per_iteration, seed + 1),
+        _summary(uncached_per_iteration, seed + 2),
+        ratio_summary,
+    )
+
+
+def _measure_unchanged(
+    backend: str, count: int, block_count: int, reads: int
+) -> dict[str, Any]:
+    ranges = _seed_ranges(backend, count)
+    cached_reference = ranges.snapshot()
+    faithful = _uncached_snapshot(ranges)
+    assert cached_reference == faithful
+    assert cached_reference is ranges.snapshot()
+    _assert_exact_snapshot(cached_reference, count=count)
+
+    def cached_call() -> RangeSnapshot:
+        return _cached_burst(ranges, reads)
+
+    def uncached_call() -> RangeSnapshot:
+        return _uncached_burst(ranges, reads)
+
+    def validate(cached_result: RangeSnapshot, uncached_result: RangeSnapshot) -> None:
+        assert cached_result is cached_reference
+        assert uncached_result == cached_reference
+        assert uncached_result is not cached_reference
+        _assert_exact_snapshot(cached_result, count=count)
+
+    iterations, pilot = _pilot(cached_call, uncached_call, validate)
+    seed = BOOTSTRAP_SEED + count
+    blocks, ratios, cached_ns, uncached_ns, ratio = _balanced_blocks(
+        cached_call,
+        uncached_call,
+        validate,
+        block_count=block_count,
+        iterations=iterations,
+        seed=seed,
+    )
+    return {
+        "kind": "unchanged_read_burst",
+        "interval_count": count,
+        "operations_per_iteration": reads,
+        "iterations_per_position": iterations,
+        "pilot": pilot,
+        "blocks": blocks,
+        "block_ratios": ratios,
+        "cached_ns_per_iteration": cached_ns,
+        "uncached_ns_per_iteration": uncached_ns,
+        "ratio": ratio,
+        "validated_blocks": block_count,
+        "final_snapshot_sha256": _snapshot_digest(cached_reference),
+    }
+
+
+def _measure_write_observe(
+    backend: str, count: int, block_count: int
+) -> dict[str, Any]:
+    cached_ranges = _seed_ranges(backend, count)
+    uncached_ranges = _seed_ranges(backend, count)
+    cached_initial = cached_ranges.snapshot()
+    uncached_initial = _uncached_snapshot(uncached_ranges)
+    assert cached_initial == uncached_initial
+
+    def cached_call() -> tuple[Any, RangeSnapshot, Any, RangeSnapshot]:
+        return _restorative_cycle(cached_ranges, RangeSet.snapshot, count)
+
+    def uncached_call() -> tuple[Any, RangeSnapshot, Any, RangeSnapshot]:
+        return _restorative_cycle(uncached_ranges, _uncached_snapshot, count)
+
+    def validate(
+        cached_result: tuple[Any, RangeSnapshot, Any, RangeSnapshot],
+        uncached_result: tuple[Any, RangeSnapshot, Any, RangeSnapshot],
+    ) -> None:
+        _validate_cycle(cached_result, count)
+        _validate_cycle(uncached_result, count)
+        assert cached_result == uncached_result
+        assert cached_result[3] is cached_ranges.snapshot()
+        assert cached_result[3] is not cached_initial
+        assert uncached_result[3] is not uncached_ranges.snapshot()
+        assert cached_ranges.intervals() == uncached_ranges.intervals()
+
+    iterations, pilot = _pilot(cached_call, uncached_call, validate)
+    seed = BOOTSTRAP_SEED + count * 2
+    blocks, ratios, cached_ns, uncached_ns, ratio = _balanced_blocks(
+        cached_call,
+        uncached_call,
+        validate,
+        block_count=block_count,
+        iterations=iterations,
+        seed=seed,
+    )
+    return {
+        "kind": "write_then_observe_restorative",
+        "interval_count": count,
+        "operations_per_iteration": 4,
+        "iterations_per_position": iterations,
+        "pilot": pilot,
+        "blocks": blocks,
+        "block_ratios": ratios,
+        "cached_ns_per_iteration": cached_ns,
+        "uncached_ns_per_iteration": uncached_ns,
+        "ratio": ratio,
+        "validated_blocks": block_count,
+        "final_snapshot_sha256": _snapshot_digest(cached_ranges.snapshot()),
+    }
+
+
+def _gate(rows: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    unchanged = {
+        row["interval_count"]: row
+        for row in rows
+        if row["kind"] == "unchanged_read_burst"
+    }
+    write_rows = [
+        row for row in rows if row["kind"] == "write_then_observe_restorative"
+    ]
+    target = unchanged.get(10_000)
+    unchanged_upper = None if target is None else target["ratio"]["median_95_high"]
+    unchanged_pass = (
+        type(unchanged_upper) is float and unchanged_upper <= UNCHANGED_N10000_LIMIT
+    )
+    n1000 = unchanged.get(1_000)
+    if target is None or n1000 is None:
+        scaling_ratio = None
+    else:
+        scaling_ratio = (
+            target["cached_ns_per_iteration"]["median"]
+            / n1000["cached_ns_per_iteration"]["median"]
+        )
+    scaling_pass = (
+        type(scaling_ratio) is float and scaling_ratio <= CACHED_SCALING_LIMIT
+    )
+    write_upper = max(
+        (row["ratio"]["median_95_high"] for row in write_rows), default=None
+    )
+    write_pass = (
+        len(write_rows) == len(INTERVAL_COUNTS)
+        and type(write_upper) is float
+        and write_upper <= WRITE_OBSERVE_LIMIT
+    )
+    accepted = unchanged_pass and scaling_pass and write_pass
+    return {
+        "unchanged_n10000_upper95": unchanged_upper,
+        "unchanged_n10000_limit": UNCHANGED_N10000_LIMIT,
+        "unchanged_n10000_pass": unchanged_pass,
+        "cached_n10000_over_n1000_median": scaling_ratio,
+        "cached_scaling_limit": CACHED_SCALING_LIMIT,
+        "cached_scaling_pass": scaling_pass,
+        "write_observe_worst_upper95": write_upper,
+        "write_observe_limit": WRITE_OBSERVE_LIMIT,
+        "write_observe_pass": write_pass,
+        "decision": "ACCEPTED" if accepted else "REJECTED",
+    }
+
+
+def _git_metadata() -> dict[str, Any]:
+    def git(*args: str) -> str:
+        return subprocess.run(
+            ["git", *args],
+            cwd=_REPOSITORY_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+
+    status = git("status", "--porcelain=v1")
+    changed_paths = sorted(
+        line
+        for line in git(
+            "ls-files", "--modified", "--others", "--exclude-standard"
+        ).splitlines()
+        if line
+    )
+    staged_files = sorted(
+        line for line in git("diff", "--cached", "--name-only").splitlines() if line
+    )
+    source_state = hashlib.sha256(status.encode())
+    source_state.update(
+        subprocess.run(
+            ["git", "diff", "--binary", "HEAD"],
+            cwd=_REPOSITORY_ROOT,
+            check=True,
+            capture_output=True,
+        ).stdout
+    )
+    for relative in changed_paths:
+        candidate = _REPOSITORY_ROOT / relative
+        source_state.update(relative.encode())
+        source_state.update(b"\0")
+        if candidate.is_file():
+            source_state.update(hashlib.sha256(candidate.read_bytes()).digest())
+    return {
+        "commit": git("rev-parse", "HEAD").strip(),
+        "head_tree": git("rev-parse", "HEAD^{tree}").strip(),
+        "clean_worktree": not status,
+        "changed_paths": changed_paths,
+        "staged_files": staged_files,
+        "source_state_sha256": source_state.hexdigest(),
+    }
+
+
+def _display_path(path: Path) -> str:
+    resolved = path.resolve()
+    try:
+        return str(resolved.relative_to(_REPOSITORY_ROOT))
+    except ValueError:
+        return str(resolved)
+
+
+def _file_provenance(path: Path) -> dict[str, str]:
+    resolved = path.resolve()
+    return {
+        "path": _display_path(resolved),
+        "sha256": hashlib.sha256(resolved.read_bytes()).hexdigest(),
+    }
+
+
+def _compiler_version() -> str:
+    compiler = os.environ.get("CXX", "c++")
+    try:
+        completed = subprocess.run(
+            [compiler, "--version"], check=True, capture_output=True, text=True
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return "unavailable"
+    return completed.stdout.splitlines()[0] if completed.stdout else "unavailable"
+
+
+def _runtime_provenance() -> dict[str, str]:
+    return {
+        "python_version": platform.python_version(),
+        "python_implementation": platform.python_implementation(),
+        "python_compiler": platform.python_compiler(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "architecture": platform.architecture()[0],
+    }
+
+
+def _build_provenance() -> dict[str, Any]:
+    return {
+        "command": os.environ.get("TREE_MENDOUS_BUILD_COMMAND", "uv sync --all-extras"),
+        "cxx": os.environ.get("CXX", "c++"),
+        "cxx_version": _compiler_version(),
+        "cc": str(sysconfig.get_config_var("CC") or "unknown"),
+        "cflags": str(sysconfig.get_config_var("CFLAGS") or "unknown"),
+        "flags": {name: os.environ.get(name, "") for name in BUILD_FLAG_NAMES},
+    }
+
+
+def _backend_provenance() -> dict[str, str]:
+    ranges = _seed_ranges(BACKEND, 1)
+    implementation_type = type(ranges._adapter.implementation)
+    implementation_path = Path(inspect.getfile(implementation_type))
+    return {
+        "id": BACKEND,
+        "module": implementation_type.__module__,
+        "type": implementation_type.__qualname__,
+        **_file_provenance(implementation_path),
+    }
+
+
+def _provenance() -> dict[str, Any]:
+    return {
+        "git": _git_metadata(),
+        "sources": [
+            _file_provenance(Path(__file__)),
+            _file_provenance(_REPOSITORY_ROOT / "treemendous" / "rangeset.py"),
+        ],
+        "runtime": _runtime_provenance(),
+        "build": _build_provenance(),
+        "backend": _backend_provenance(),
+    }
+
+
+def _methodology() -> dict[str, Any]:
+    return {
+        "interval_counts": list(INTERVAL_COUNTS),
+        "unchanged_reads_per_iteration": UNCHANGED_READS,
+        "confirmation_blocks": CONFIRMATION_BLOCKS,
+        "minimum_blocks": MINIMUM_BLOCKS,
+        "balanced_block_method": BALANCED_BLOCK_METHOD,
+        "pilot_method": PILOT_METHOD,
+        "pilot_target_ns": PILOT_TARGET_NS,
+        "pilot_minimum_iterations": PILOT_MIN_ITERATIONS,
+        "pilot_maximum_iterations": PILOT_MAX_ITERATIONS,
+        "bootstrap_resamples": BOOTSTRAP_RESAMPLES,
+        "bootstrap_seed": BOOTSTRAP_SEED,
+        "timed_boundary": TIMED_BOUNDARY,
+    }
+
+
+def run_matrix(
+    *,
+    backend: str = BACKEND,
+    blocks: int = CONFIRMATION_BLOCKS,
+) -> dict[str, Any]:
+    if backend != BACKEND:
+        raise ValueError(f"snapshot experiment backend must be {BACKEND!r}")
+    if type(blocks) is not int or blocks != CONFIRMATION_BLOCKS:
+        raise ValueError(
+            f"blocks must equal fixed confirmation count {CONFIRMATION_BLOCKS}"
+        )
+    rows: list[dict[str, Any]] = []
+    for count in INTERVAL_COUNTS:
+        rows.append(_measure_unchanged(backend, count, blocks, UNCHANGED_READS))
+        rows.append(_measure_write_observe(backend, count, blocks))
+    return {
+        "schema": SCHEMA,
+        "blocks": blocks,
+        "methodology": _methodology(),
+        "rows": rows,
+        "gate": _gate(rows),
+        "provenance": _provenance(),
+    }
+
+
+def _markdown(report: dict[str, Any], digest: str) -> str:
+    lines = [
+        "# RangeSet geometry snapshot cache experiment",
+        "",
+        f"Decision: **{report['gate']['decision']}**",
+        f"JSON SHA-256: `{digest}`",
+        "",
+        "| workload | N | iterations | cached median ns/iteration | uncached median ns/iteration | ratio | upper 95% |",
+        "| --- | ---: | ---: | ---: | ---: | ---: | ---: |",
+    ]
+    lines.extend(
+        f"| {row['kind']} | {row['interval_count']} | "
+        f"{row['iterations_per_position']} | "
+        f"{row['cached_ns_per_iteration']['median']:.0f} | "
+        f"{row['uncached_ns_per_iteration']['median']:.0f} | "
+        f"{row['ratio']['median']:.4f} | "
+        f"{row['ratio']['median_95_high']:.4f} |"
+        for row in report["rows"]
+    )
+    gate = report["gate"]
+    lines.extend(
+        (
+            "",
+            f"- N=10000 unchanged upper-95: {gate['unchanged_n10000_upper95']}",
+            "- cached N=10000/N=1000 median: "
+            f"{gate['cached_n10000_over_n1000_median']}",
+            "- write-then-observe worst upper-95: "
+            f"{gate['write_observe_worst_upper95']}",
+        )
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_artifacts(report: dict[str, Any], output: Path) -> tuple[Path, Path, Path]:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (
+        json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    ).encode()
+    output.write_bytes(encoded)
+    digest = hashlib.sha256(encoded).hexdigest()
+    markdown = output.with_suffix(".md")
+    markdown.write_text(_markdown(report, digest))
+    checksum = Path(f"{output}.sha256")
+    checksum.write_text(f"{digest}  {output.name}\n")
+    return output, markdown, checksum
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate key: {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite(value: str) -> None:
+    raise ValueError(f"non-finite number: {value}")
+
+
+def _finite_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"non-finite number: {value}")
+    return parsed
+
+
+def _exact_equal(left: Any, right: Any) -> bool:
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, dict):
+        return left.keys() == right.keys() and all(
+            _exact_equal(left[key], right[key]) for key in left
+        )
+    if isinstance(left, list):
+        return len(left) == len(right) and all(
+            _exact_equal(a, b) for a, b in zip(left, right, strict=True)
+        )
+    return bool(left == right)
+
+
+def _require_keys(value: Any, keys: set[str], label: str) -> dict[str, Any]:
+    if type(value) is not dict or set(value) != keys:
+        raise ValueError(f"{label} keys/type mismatch")
+    return value
+
+
+def _is_sha256(value: Any) -> bool:
+    return (
+        type(value) is str
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _is_git_oid(value: Any) -> bool:
+    return (
+        type(value) is str
+        and len(value) == 40
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _verify_summary(summary: Any, samples: list[int | float], seed: int) -> None:
+    _require_keys(summary, {"median", "median_95_low", "median_95_high"}, "summary")
+    if any(
+        type(value) is not float or not math.isfinite(value)
+        for value in summary.values()
+    ):
+        raise ValueError("summary exact type/non-finite mismatch")
+    if not _exact_equal(summary, _summary(samples, seed)):
+        raise ValueError("derived summary mismatch")
+
+
+def verify_artifacts(output: Path) -> dict[str, Any]:
+    encoded = output.read_bytes()
+    digest = hashlib.sha256(encoded).hexdigest()
+    if Path(f"{output}.sha256").read_text() != f"{digest}  {output.name}\n":
+        raise ValueError("checksum mismatch")
+    report = json.loads(
+        encoded,
+        object_pairs_hook=_reject_duplicate_keys,
+        parse_constant=_reject_nonfinite,
+        parse_float=_finite_float,
+    )
+    _require_keys(
+        report,
+        {"schema", "blocks", "methodology", "rows", "gate", "provenance"},
+        "report",
+    )
+    if report["schema"] != SCHEMA:
+        raise ValueError("schema mismatch")
+    blocks = report["blocks"]
+    if type(blocks) is not int or blocks != CONFIRMATION_BLOCKS:
+        raise ValueError("fixed block count exact type/value mismatch")
+    methodology = _require_keys(
+        report["methodology"], set(_methodology()), "methodology"
+    )
+    if not _exact_equal(methodology, _methodology()):
+        raise ValueError("fixed matrix/methodology mismatch")
+    expected_pairs = [
+        (kind, count)
+        for count in INTERVAL_COUNTS
+        for kind in ("unchanged_read_burst", "write_then_observe_restorative")
+    ]
+    if type(report["rows"]) is not list or len(report["rows"]) != len(expected_pairs):
+        raise ValueError("row shape mismatch")
+    observed_pairs: list[tuple[str, int]] = []
+    row_keys = {
+        "kind",
+        "interval_count",
+        "operations_per_iteration",
+        "iterations_per_position",
+        "pilot",
+        "blocks",
+        "block_ratios",
+        "cached_ns_per_iteration",
+        "uncached_ns_per_iteration",
+        "ratio",
+        "validated_blocks",
+        "final_snapshot_sha256",
+    }
+    pilot_keys = {
+        "target_position_ns",
+        "maximum_iterations",
+        "order",
+        "measurements",
+        "selected_iterations",
+        "target_reached_by_both",
+        "excluded_from_blocks_and_gates",
+    }
+    for row in report["rows"]:
+        _require_keys(row, row_keys, "row")
+        if type(row["kind"]) is not str or type(row["interval_count"]) is not int:
+            raise ValueError("row identity exact type mismatch")
+        observed_pairs.append((row["kind"], row["interval_count"]))
+        expected_operations = (
+            methodology["unchanged_reads_per_iteration"]
+            if row["kind"] == "unchanged_read_burst"
+            else 4
+        )
+        if row["operations_per_iteration"] != expected_operations:
+            raise ValueError("row operation count mismatch")
+        iterations = row["iterations_per_position"]
+        if (
+            type(iterations) is not int
+            or iterations < PILOT_MIN_ITERATIONS
+            or iterations > PILOT_MAX_ITERATIONS
+        ):
+            raise ValueError("position iteration count mismatch")
+        if row["validated_blocks"] != blocks:
+            raise ValueError("validated block count mismatch")
+
+        pilot = _require_keys(row["pilot"], pilot_keys, "pilot")
+        if (
+            pilot["target_position_ns"] != PILOT_TARGET_NS
+            or pilot["maximum_iterations"] != PILOT_MAX_ITERATIONS
+            or pilot["order"] != "cached_then_uncached"
+            or pilot["selected_iterations"] != iterations
+            or pilot["excluded_from_blocks_and_gates"] is not True
+            or type(pilot["target_reached_by_both"]) is not bool
+        ):
+            raise ValueError("pilot fixed methodology/type mismatch")
+        measurements = pilot["measurements"]
+        if type(measurements) is not list or not measurements:
+            raise ValueError("pilot measurement shape mismatch")
+        expected_iteration = PILOT_MIN_ITERATIONS
+        for index, measurement in enumerate(measurements):
+            _require_keys(
+                measurement,
+                {"iterations", "cached_ns", "uncached_ns"},
+                "pilot measurement",
+            )
+            if (
+                measurement["iterations"] != expected_iteration
+                or type(measurement["cached_ns"]) is not int
+                or measurement["cached_ns"] <= 0
+                or type(measurement["uncached_ns"]) is not int
+                or measurement["uncached_ns"] <= 0
+            ):
+                raise ValueError("pilot duration/iteration mismatch")
+            reached = (
+                min(measurement["cached_ns"], measurement["uncached_ns"])
+                >= PILOT_TARGET_NS
+            )
+            if index < len(measurements) - 1 and (
+                reached or expected_iteration == PILOT_MAX_ITERATIONS
+            ):
+                raise ValueError("pilot stopping derivation mismatch")
+            expected_iteration = min(expected_iteration * 2, PILOT_MAX_ITERATIONS)
+        final_pilot = measurements[-1]
+        reached = (
+            min(final_pilot["cached_ns"], final_pilot["uncached_ns"]) >= PILOT_TARGET_NS
+        )
+        if (
+            final_pilot["iterations"] != iterations
+            or pilot["target_reached_by_both"] is not reached
+            or (not reached and iterations != PILOT_MAX_ITERATIONS)
+        ):
+            raise ValueError("pilot selection derivation mismatch")
+
+        raw_blocks = row["blocks"]
+        if type(raw_blocks) is not list or len(raw_blocks) != blocks:
+            raise ValueError("raw block shape mismatch")
+        cached_totals: list[int] = []
+        uncached_totals: list[int] = []
+        derived_ratios: list[float] = []
+        for block_index, block in enumerate(raw_blocks):
+            _require_keys(
+                block,
+                {
+                    "block_index",
+                    "positions",
+                    "cached_ns_total",
+                    "uncached_ns_total",
+                    "ratio",
+                },
+                "block",
+            )
+            expected_orderings = (
+                ["cached_first", "uncached_first"]
+                if block_index % 2 == 0
+                else ["uncached_first", "cached_first"]
+            )
+            if (
+                block["block_index"] != block_index
+                or type(block["positions"]) is not list
+            ):
+                raise ValueError("block index/position shape mismatch")
+            if len(block["positions"]) != 2:
+                raise ValueError("balanced block position count mismatch")
+            for position, ordering in zip(
+                block["positions"], expected_orderings, strict=True
+            ):
+                _require_keys(
+                    position, {"ordering", "cached_ns", "uncached_ns"}, "position"
+                )
+                if (
+                    position["ordering"] != ordering
+                    or type(position["cached_ns"]) is not int
+                    or position["cached_ns"] <= 0
+                    or type(position["uncached_ns"]) is not int
+                    or position["uncached_ns"] <= 0
+                ):
+                    raise ValueError("balanced block ordering/duration mismatch")
+            cached_total = sum(position["cached_ns"] for position in block["positions"])
+            uncached_total = sum(
+                position["uncached_ns"] for position in block["positions"]
+            )
+            ratio = cached_total / uncached_total
+            if (
+                block["cached_ns_total"] != cached_total
+                or block["uncached_ns_total"] != uncached_total
+                or type(block["ratio"]) is not float
+                or not math.isfinite(block["ratio"])
+                or block["ratio"] != ratio
+            ):
+                raise ValueError("raw block total/ratio derivation mismatch")
+            cached_totals.append(cached_total)
+            uncached_totals.append(uncached_total)
+            derived_ratios.append(ratio)
+
+        seed = BOOTSTRAP_SEED + row["interval_count"] * (
+            1 if row["kind"] == "unchanged_read_burst" else 2
+        )
+        divisor = 2 * iterations
+        cached_per_iteration = [value / divisor for value in cached_totals]
+        uncached_per_iteration = [value / divisor for value in uncached_totals]
+        _verify_summary(row["cached_ns_per_iteration"], cached_per_iteration, seed + 1)
+        _verify_summary(
+            row["uncached_ns_per_iteration"], uncached_per_iteration, seed + 2
+        )
+        ratios, ratio_summary = _ratio_summary(cached_totals, uncached_totals, seed)
+        if not _exact_equal(row["block_ratios"], derived_ratios) or not _exact_equal(
+            row["block_ratios"], ratios
+        ):
+            raise ValueError("raw block ratios mismatch")
+        if not _exact_equal(row["ratio"], ratio_summary):
+            raise ValueError("derived block ratio interval mismatch")
+        if not _is_sha256(row["final_snapshot_sha256"]):
+            raise ValueError("snapshot digest exact type/value mismatch")
+        if row["final_snapshot_sha256"] != _expected_snapshot_digest(
+            row["interval_count"]
+        ):
+            raise ValueError("snapshot digest semantic mismatch")
+    if observed_pairs != expected_pairs:
+        raise ValueError("row matrix membership/order mismatch")
+    _require_keys(
+        report["gate"],
+        {
+            "unchanged_n10000_upper95",
+            "unchanged_n10000_limit",
+            "unchanged_n10000_pass",
+            "cached_n10000_over_n1000_median",
+            "cached_scaling_limit",
+            "cached_scaling_pass",
+            "write_observe_worst_upper95",
+            "write_observe_limit",
+            "write_observe_pass",
+            "decision",
+        },
+        "gate",
+    )
+    expected_gate = _gate(report["rows"])
+    if not _exact_equal(report["gate"], expected_gate):
+        raise ValueError("gate mismatch")
+    provenance = _require_keys(
+        report["provenance"],
+        {"git", "sources", "runtime", "build", "backend"},
+        "provenance",
+    )
+    git = _require_keys(
+        provenance["git"],
+        {
+            "commit",
+            "head_tree",
+            "clean_worktree",
+            "changed_paths",
+            "staged_files",
+            "source_state_sha256",
+        },
+        "git provenance",
+    )
+    if (
+        not _is_git_oid(git["commit"])
+        or not _is_git_oid(git["head_tree"])
+        or type(git["clean_worktree"]) is not bool
+        or type(git["changed_paths"]) is not list
+        or type(git["staged_files"]) is not list
+        or any(type(value) is not str for value in git["changed_paths"])
+        or any(type(value) is not str for value in git["staged_files"])
+        or not _is_sha256(git["source_state_sha256"])
+    ):
+        raise ValueError("git provenance exact type/value mismatch")
+    if not _exact_equal(git, _git_metadata()):
+        raise ValueError("git/source-state provenance does not match local checkout")
+    if not _exact_equal(provenance["runtime"], _runtime_provenance()):
+        raise ValueError("runtime provenance does not match current runtime")
+    if not _exact_equal(provenance["build"], _build_provenance()):
+        raise ValueError("build provenance does not match current build")
+    expected_sources = [
+        _file_provenance(Path(__file__)),
+        _file_provenance(_REPOSITORY_ROOT / "treemendous" / "rangeset.py"),
+    ]
+    if not _exact_equal(provenance["sources"], expected_sources):
+        raise ValueError("source provenance path/hash mismatch")
+    if not _exact_equal(provenance["backend"], _backend_provenance()):
+        raise ValueError("active backend identity/module/type/path/hash mismatch")
+    canonical = (
+        json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    ).encode()
+    if canonical != encoded:
+        raise ValueError("JSON is not canonical")
+    if output.with_suffix(".md").read_text() != _markdown(report, digest):
+        raise ValueError("Markdown mismatch")
+    return report
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--backend", default=BACKEND)
+    parser.add_argument("--blocks", type=int, default=CONFIRMATION_BLOCKS)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--verify", action="store_true")
+    args = parser.parse_args(argv)
+    if args.verify:
+        report = verify_artifacts(args.output)
+    else:
+        report = run_matrix(backend=args.backend, blocks=args.blocks)
+        write_artifacts(report, args.output)
+        verify_artifacts(args.output)
+    print(
+        json.dumps(
+            {"artifact": str(args.output), "gate": report["gate"]}, sort_keys=True
+        )
+    )
+    return 0 if args.verify or report["gate"]["decision"] == "ACCEPTED" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/performance/experiments/rangeset_transaction.py
+++ b/tests/performance/experiments/rangeset_transaction.py
@@ -1,0 +1,1074 @@
+#!/usr/bin/env python3
+"""Ordered, payload-aware ``RangeSet`` transaction experiment.
+
+This module is deliberately outside :mod:`treemendous`.  The candidate uses
+private ``RangeSet`` state to test copy/stage/publish economics without adding a
+stable API.  It never compensates a partially applied source mutation: all
+fallible work targets a fresh backend, followed by one ``__dict__`` reference
+publication while the original lock is held.
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import hashlib
+import inspect
+import json
+import math
+import os
+import platform
+import random
+import statistics
+import subprocess
+import sysconfig
+import time
+import tracemalloc
+from collections.abc import Callable, Iterable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from treemendous.backends.adapters import BackendAdapter
+from treemendous.backends.catalog import CATALOG
+from treemendous.backends.types import Capability, Maturity
+from treemendous.domain import IntervalResult, MutationResult, RangeSnapshot, Span
+from treemendous.policies import (
+    JoinPayloadPolicy,
+    OrderedPayloadPolicy,
+    PayloadPolicy,
+    UniformPayloadPolicy,
+)
+from treemendous.rangeset import _MISSING, RangeSet
+
+SCHEMA = "treemendous-rangeset-transaction-experiment-v1"
+BACKEND = "py_boundary"
+BUILD_FLAG_NAMES = (
+    "BOOST_ROOT",
+    "TREE_MENDOUS_DISABLE_OPTIMIZATIONS",
+    "TREE_MENDOUS_GLIBCXX_DEBUG",
+    "TREE_MENDOUS_LOCAL_NATIVE",
+    "TREE_MENDOUS_SANITIZERS",
+    "TREE_MENDOUS_WITH_ICL",
+)
+MINIMUM_SAMPLES = 15
+BATCH_SIZES = (0, 1, 4, 16, 64)
+INTERVAL_COUNTS = (64, 1_000)
+PAYLOAD_KINDS = ("none", "uniform", "join", "ordered")
+TRACE_KINDS = ("restorative", "non_restorative")
+BOOTSTRAP_RESAMPLES = 2_000
+BOOTSTRAP_SEED = 76_031
+_REPOSITORY_ROOT = Path(__file__).resolve().parents[3]
+
+
+@dataclass(frozen=True)
+class _TransactionOperation:
+    """One immutable experiment operation descriptor."""
+
+    action: Literal["add", "discard", "strict-discard"]
+    span: Span
+    payload: Any = _MISSING
+
+    def __post_init__(self) -> None:
+        if self.action not in ("add", "discard", "strict-discard"):
+            raise ValueError(f"unsupported transaction action: {self.action!r}")
+        if self.action != "add" and self.payload is not _MISSING:
+            raise ValueError("discard operations cannot carry payload")
+
+
+class _UnsupportedAdapterError(ValueError):
+    """Raised when an experiment source has no exact catalog factory proof."""
+
+
+BackendFactory = Callable[[], Any]
+ResultFactory = Callable[[tuple[Span, ...], int, bool], Any]
+
+
+def _proven_backend_factory(source: RangeSet) -> tuple[str, BackendFactory]:
+    """Prove factory provenance by exact implementation class and stable spec."""
+    implementation_type = type(source._adapter.implementation)
+    matches = []
+    for spec in CATALOG:
+        if not (
+            spec.maturity is Maturity.STABLE
+            and spec.deterministic
+            and Capability.CORE in spec.capabilities
+        ):
+            continue
+        try:
+            catalog_type = spec.loader()
+        except (ImportError, OSError):
+            continue
+        if catalog_type is implementation_type:
+            matches.append(spec)
+    if len(matches) != 1:
+        raise _UnsupportedAdapterError(
+            "transaction experiment requires one exact stable deterministic "
+            "CORE catalog factory; direct/custom adapters are unsupported"
+        )
+    spec = matches[0]
+
+    def factory() -> Any:
+        return spec.loader()(**dict(spec.constructor_args))
+
+    return spec.id, factory
+
+
+def _coerce_operation(row: Any) -> _TransactionOperation:
+    if isinstance(row, _TransactionOperation):
+        return row
+    if not isinstance(row, tuple) or len(row) not in (2, 3):
+        raise TypeError("transaction rows must be _TransactionOperation or 2/3-tuples")
+    action = row[0]
+    raw_span = row[1]
+    span = raw_span if isinstance(raw_span, Span) else Span(*raw_span)
+    payload = row[2] if len(row) == 3 else _MISSING
+    return _TransactionOperation(action, span, payload)
+
+
+def _clone_source_into_stage(
+    source: RangeSet,
+    factory: BackendFactory,
+    timings: dict[str, int] | None = None,
+) -> RangeSet:
+    """Build a fresh backend and clone complete geometry/payload/event state."""
+    factory_started = time.perf_counter_ns()
+    implementation = factory()
+    staged = RangeSet(
+        BackendAdapter(implementation),
+        domain=source._domain,
+        initially_available=False,
+        payload_policy=source._payload_policy,
+        payload_cloner=source._payload_cloner,
+    )
+
+    # Read the raw geometry rather than trusting a possibly deferred cache.
+    geometry = tuple(source._adapter.intervals())
+    backend_load_started = time.perf_counter_ns()
+    for interval in geometry:
+        staged._adapter.release(interval.start, interval.end)
+    backend_load_finished = time.perf_counter_ns()
+    staged._geometry_cache = geometry
+    staged._geometry_cache_valid = True
+    staged._pending_geometry_update = None
+    staged._total_free = source._total_free
+
+    if source._payload_segments is not None:
+        with source._payload_processing():
+            staged._owned_payload_identity = source._clone_payload(
+                source._owned_payload_identity
+            )
+            staged._payload_segments = source._clone_segments(source._payload_segments)
+            staged._ordered_events = (
+                None
+                if source._ordered_events is None
+                else source._clone_events(source._ordered_events)
+            )
+    if timings is not None:
+        timings["backend_load_ns"] = backend_load_finished - backend_load_started
+        timings["stage_ns"] = time.perf_counter_ns() - factory_started
+    return staged
+
+
+def _replay(
+    staged: RangeSet, operations: tuple[_TransactionOperation, ...]
+) -> tuple[MutationResult, ...]:
+    rows: list[MutationResult] = []
+    for operation in operations:
+        if operation.action == "add":
+            if operation.payload is _MISSING:
+                rows.append(staged.add(operation.span))
+            else:
+                rows.append(staged.add(operation.span, operation.payload))
+        else:
+            rows.append(
+                staged.discard(
+                    operation.span,
+                    require_covered=operation.action == "strict-discard",
+                )
+            )
+    return tuple(rows)
+
+
+def _rangeset_transaction(
+    source: RangeSet,
+    operations: Iterable[_TransactionOperation | tuple[Any, ...]],
+    *,
+    _result_factory: ResultFactory | None = None,
+    _timings: dict[str, int] | None = None,
+) -> tuple[MutationResult, ...]:
+    """Stage ordered scalar mutations and atomically publish the staged state.
+
+    Every iterable, policy, clone, backend, and result-construction callback is
+    completed while the original state is guarded and before publication.
+    Failure simply drops the staged object; the source backend is never touched.
+    """
+    if not isinstance(source, RangeSet):
+        raise TypeError("source must be an exact RangeSet")
+
+    lock = source._lock
+    lock.acquire()
+    original_state = source.__dict__
+    published = False
+    activity_lock = source._payload_activity_lock
+    guarded_payload = source._payload_policy is not None
+    try:
+        if source._authoritative_mutation_active or source._payload_is_active():
+            raise RuntimeError(
+                "reentrant transaction on the same RangeSet is not allowed"
+            )
+        source._authoritative_mutation_active = True
+        if guarded_payload:
+            with activity_lock:
+                source._payload_activity += 1
+
+        # Factory proof deliberately precedes iteration/materialization/staging.
+        total_started = time.perf_counter_ns()
+        _, factory = _proven_backend_factory(source)
+        materialize_started = time.perf_counter_ns()
+        materialized = tuple(_coerce_operation(row) for row in operations)
+        stage_timings: dict[str, int] = {}
+        staged = _clone_source_into_stage(source, factory, stage_timings)
+        replay_started = time.perf_counter_ns()
+        scalar_rows = _replay(staged, materialized)
+
+        make_result = MutationResult if _result_factory is None else _result_factory
+        prepared = tuple(
+            make_result(row.changed, row.changed_length, row.fully_covered)
+            for row in scalar_rows
+        )
+        if any(type(row) is not MutationResult for row in prepared):
+            raise TypeError(
+                "transaction result factory must return exact MutationResult"
+            )
+        if _timings is not None:
+            now = time.perf_counter_ns()
+            _timings.update(stage_timings)
+            _timings["materialize_ns"] = (
+                replay_started - materialize_started - stage_timings["stage_ns"]
+            )
+            _timings["replay_result_ns"] = now - replay_started
+            _timings["prepublish_total_ns"] = now - total_started
+
+        # Prepare the published dictionary completely.  The source retains its
+        # synchronization objects; publication itself is one noexcept reference
+        # assignment and allocates nothing.
+        staged._lock = lock
+        staged._payload_activity_lock = activity_lock
+        staged._payload_activity = 0
+        staged._authoritative_mutation_active = False
+        published_state = staged.__dict__
+        source.__dict__ = published_state
+        published = True
+        return prepared
+    finally:
+        if not published:
+            original_state["_authoritative_mutation_active"] = False
+            if guarded_payload:
+                with activity_lock:
+                    original_state["_payload_activity"] -= 1
+        lock.release()
+
+
+# ---------------------------------------------------------------------------
+# Bounded paired benchmark and strict artifact triplet.
+
+
+def _policy(kind: str) -> PayloadPolicy[Any] | None:
+    if kind == "none":
+        return None
+    if kind == "uniform":
+        return UniformPayloadPolicy()
+    if kind == "join":
+        return JoinPayloadPolicy(lambda left, right: left | right, frozenset())
+    if kind == "ordered":
+        return OrderedPayloadPolicy(
+            lambda left, right: left + right,
+            (),
+            event_key_fn=lambda value: value,
+        )
+    raise ValueError(f"unknown payload kind: {kind}")
+
+
+def _payload(kind: str, index: int) -> Any:
+    if kind == "uniform":
+        return index
+    if kind == "join":
+        return frozenset({index})
+    if kind == "ordered":
+        return (index,)
+    return _MISSING
+
+
+def _seed_ranges(backend: str, count: int, payload_kind: str) -> RangeSet:
+    from treemendous import create_range_set
+
+    ranges = create_range_set(
+        (0, count * 4 + 4),
+        backend=backend,
+        initially_available=False,
+        payload_policy=_policy(payload_kind),
+    )
+    # Direct construction avoids O(N^3) ordered-policy setup while preserving
+    # the exact valid internal state scalar add would create for disjoint spans.
+    geometry = tuple(IntervalResult(i * 4, i * 4 + 2) for i in range(count))
+    for interval in geometry:
+        ranges._adapter.release(interval.start, interval.end)
+    ranges._geometry_cache = geometry
+    ranges._total_free = count * 2
+    if payload_kind != "none":
+        segments = [
+            IntervalResult(item.start, item.end, data=_payload(payload_kind, i))
+            for i, item in enumerate(geometry)
+        ]
+        ranges._payload_segments = segments
+        if payload_kind == "ordered":
+            ranges._ordered_events = [
+                ranges._ordered_event(item.span, item.data) for item in segments
+            ]
+    return ranges
+
+
+def _trace(
+    count: int, batch_size: int, payload_kind: str, trace_kind: str
+) -> tuple[_TransactionOperation, ...]:
+    operations: list[_TransactionOperation] = []
+    for index in range(batch_size):
+        target = (index // 2) % count
+        base = target * 4
+        action: Literal["add", "discard", "strict-discard"]
+        if trace_kind == "restorative":
+            action = "discard" if index % 2 == 0 else "add"
+            span = Span(base, base + 2)
+        else:
+            action = "add" if index % 3 else "strict-discard"
+            span = (
+                Span(base + 2, base + 3)
+                if action == "add"
+                else Span(base + 3, base + 4)
+            )
+        payload = _payload(payload_kind, target) if action == "add" else _MISSING
+        operations.append(_TransactionOperation(action, span, payload))
+    return tuple(operations)
+
+
+def _scalar(
+    ranges: RangeSet, operations: Sequence[_TransactionOperation]
+) -> tuple[MutationResult, ...]:
+    return _replay(ranges, tuple(operations))
+
+
+def _freeze_results(rows: Sequence[MutationResult]) -> list[Any]:
+    return [
+        [
+            [[span.start, span.end] for span in row.changed],
+            row.changed_length,
+            row.fully_covered,
+        ]
+        for row in rows
+    ]
+
+
+def _freeze_snapshot(snapshot: RangeSnapshot) -> list[Any]:
+    return [
+        [
+            item.start,
+            item.end,
+            item.data
+            if isinstance(item.data, (str, int, float, bool)) or item.data is None
+            else repr(item.data),
+        ]
+        for item in snapshot.intervals
+    ]
+
+
+def _bootstrap_interval(values: Sequence[float], seed: int) -> tuple[float, float]:
+    rng = random.Random(seed)
+    medians = []
+    for _ in range(BOOTSTRAP_RESAMPLES):
+        medians.append(
+            statistics.median(rng.choice(values) for _ in range(len(values)))
+        )
+    medians.sort()
+    return medians[int(0.025 * len(medians))], medians[int(0.975 * len(medians))]
+
+
+def _measure_case(
+    backend: str,
+    count: int,
+    batch_size: int,
+    payload_kind: str,
+    trace_kind: str,
+    samples: int,
+) -> dict[str, Any]:
+    operations = _trace(count, batch_size, payload_kind, trace_kind)
+    scalar_ns: list[int] = []
+    transaction_ns: list[int] = []
+    ratios: list[float] = []
+    peak_bytes: list[int] = []
+    stage_ns: list[int] = []
+    backend_load_ns: list[int] = []
+    prepublish_total_ns: list[int] = []
+    oracle_ranges = _seed_ranges(backend, count, payload_kind)
+    oracle_rows = _scalar(oracle_ranges, operations)
+    oracle_snapshot = oracle_ranges.snapshot()
+    result_digest = _checksum(_freeze_results(oracle_rows))
+    final_digest = _checksum(_freeze_snapshot(oracle_snapshot))
+
+    for sample in range(samples):
+        first_transaction = sample % 2 == 0
+        order = (
+            ("transaction", "scalar")
+            if first_transaction
+            else ("scalar", "transaction")
+        )
+        observed: dict[str, tuple[tuple[MutationResult, ...], RangeSnapshot]] = {}
+        elapsed: dict[str, int] = {}
+        transaction_timings: dict[str, int] = {}
+        for method in order:
+            ranges = _seed_ranges(backend, count, payload_kind)
+            gc.collect()
+            if tracemalloc.is_tracing():
+                raise AssertionError(
+                    "tracemalloc must be inactive during latency timing"
+                )
+            started = time.perf_counter_ns()
+            rows = (
+                _rangeset_transaction(ranges, operations, _timings=transaction_timings)
+                if method == "transaction"
+                else _scalar(ranges, operations)
+            )
+            elapsed[method] = time.perf_counter_ns() - started
+            observed[method] = (rows, ranges.snapshot())
+        if observed["transaction"] != (oracle_rows, oracle_snapshot) or observed[
+            "scalar"
+        ] != (oracle_rows, oracle_snapshot):
+            raise AssertionError("timed result/final state differs from scalar oracle")
+
+        # Memory is a separate untimed transaction replay.  Tracing never
+        # contaminates either latency path, and this extra run is validated.
+        memory_ranges = _seed_ranges(backend, count, payload_kind)
+        gc.collect()
+        tracemalloc.start()
+        before_peak = tracemalloc.get_traced_memory()[1]
+        memory_rows = _rangeset_transaction(memory_ranges, operations)
+        memory_peak = max(0, tracemalloc.get_traced_memory()[1] - before_peak)
+        tracemalloc.stop()
+        if (memory_rows, memory_ranges.snapshot()) != (oracle_rows, oracle_snapshot):
+            raise AssertionError("memory replay result/final state differs from oracle")
+        scalar_ns.append(elapsed["scalar"])
+        transaction_ns.append(elapsed["transaction"])
+        ratios.append(elapsed["transaction"] / max(1, elapsed["scalar"]))
+        peak_bytes.append(memory_peak)
+        stage_ns.append(transaction_timings["stage_ns"])
+        backend_load_ns.append(transaction_timings["backend_load_ns"])
+        prepublish_total_ns.append(transaction_timings["prepublish_total_ns"])
+
+    lower, upper = _bootstrap_interval(
+        ratios,
+        BOOTSTRAP_SEED + count + batch_size + sum(map(ord, payload_kind + trace_kind)),
+    )
+    return {
+        "backend": backend,
+        "interval_count": count,
+        "batch_size": batch_size,
+        "payload": payload_kind,
+        "trace": trace_kind,
+        "scalar_ns_samples": scalar_ns,
+        "transaction_ns_samples": transaction_ns,
+        "paired_ratios": ratios,
+        "ratio_median": statistics.median(ratios),
+        "ratio_95_low": lower,
+        "ratio_95_high": upper,
+        "transaction_peak_bytes_samples": peak_bytes,
+        "stage_ns_samples": stage_ns,
+        "backend_load_ns_samples": backend_load_ns,
+        "prepublish_total_ns_samples": prepublish_total_ns,
+        "result_sha256": result_digest,
+        "final_state_sha256": final_digest,
+    }
+
+
+def _checksum(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(
+            value, sort_keys=True, separators=(",", ":"), allow_nan=False
+        ).encode()
+    ).hexdigest()
+
+
+def _git_metadata() -> dict[str, Any]:
+    def run(*args: str) -> str:
+        return subprocess.run(
+            args,
+            cwd=_REPOSITORY_ROOT,
+            check=True,
+            text=True,
+            stdout=subprocess.PIPE,
+        ).stdout.strip()
+
+    status = run("git", "status", "--porcelain=v1", "--untracked-files=all")
+    changed = sorted(line[3:] for line in status.splitlines() if len(line) >= 4)
+    staged = sorted(
+        line[3:]
+        for line in status.splitlines()
+        if len(line) >= 4 and line[0] not in " ?"
+    )
+    source_material = []
+    for path in changed:
+        candidate = _REPOSITORY_ROOT / path
+        source_material.append(
+            [
+                path,
+                hashlib.sha256(candidate.read_bytes()).hexdigest()
+                if candidate.is_file()
+                else None,
+            ]
+        )
+    return {
+        "commit": run("git", "rev-parse", "HEAD"),
+        "head_tree": run("git", "rev-parse", "HEAD^{tree}"),
+        "clean_worktree": not status,
+        "changed_paths": changed,
+        "staged_files": staged,
+        "source_state_sha256": _checksum(source_material),
+    }
+
+
+def _file_provenance(relative: str) -> dict[str, str]:
+    path = (_REPOSITORY_ROOT / relative).resolve()
+    return {
+        "path": relative,
+        "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+    }
+
+
+def _compiler_version() -> str:
+    compiler = os.environ.get("CXX", "c++")
+    try:
+        completed = subprocess.run(
+            [compiler, "--version"], check=True, capture_output=True, text=True
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return "unavailable"
+    return completed.stdout.splitlines()[0] if completed.stdout else "unavailable"
+
+
+def _runtime_provenance() -> dict[str, str]:
+    return {
+        "python_version": platform.python_version(),
+        "python_implementation": platform.python_implementation(),
+        "python_compiler": platform.python_compiler(),
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "architecture": platform.architecture()[0],
+    }
+
+
+def _build_provenance() -> dict[str, Any]:
+    return {
+        "command": os.environ.get("TREE_MENDOUS_BUILD_COMMAND", "uv sync --all-extras"),
+        "cxx": os.environ.get("CXX", "c++"),
+        "cxx_version": _compiler_version(),
+        "cc": str(sysconfig.get_config_var("CC") or "unknown"),
+        "cflags": str(sysconfig.get_config_var("CFLAGS") or "unknown"),
+        "flags": {name: os.environ.get(name, "") for name in BUILD_FLAG_NAMES},
+    }
+
+
+def _binary_provenance() -> dict[str, Any]:
+    ranges = _seed_ranges(BACKEND, 1, "none")
+    implementation_type = type(ranges._adapter.implementation)
+    path = Path(inspect.getfile(implementation_type)).resolve()
+    try:
+        display_path = str(path.relative_to(_REPOSITORY_ROOT))
+    except ValueError:
+        display_path = str(path)
+    return {
+        "id": BACKEND,
+        "module": implementation_type.__module__,
+        "type": implementation_type.__qualname__,
+        "path": display_path,
+        "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+    }
+
+
+def _provenance() -> dict[str, Any]:
+    return {
+        "git": _git_metadata(),
+        "sources": [
+            _file_provenance("tests/performance/experiments/rangeset_transaction.py"),
+            _file_provenance("treemendous/rangeset.py"),
+        ],
+        "runtime": _runtime_provenance(),
+        "build": _build_provenance(),
+        "backend": _binary_provenance(),
+    }
+
+
+def _gate(rows: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    target = {
+        row["payload"]: row["ratio_95_high"]
+        for row in rows
+        if row["batch_size"] == 16
+        and row["interval_count"] == 1_000
+        and row["trace"] == "restorative"
+    }
+    target_pass = set(target) == set(PAYLOAD_KINDS) and all(
+        value <= 1.0 for value in target.values()
+    )
+    application = [
+        row["ratio_95_high"]
+        for row in rows
+        if row["trace"] == "non_restorative" and row["batch_size"] > 0
+    ]
+    application_pass = bool(application) and min(application) <= 0.90
+    supported = [row for row in rows if row["batch_size"] > 0]
+    regression_pass = bool(supported) and all(
+        row["ratio_95_high"] <= 1.10 for row in supported
+    )
+    accepted = target_pass and application_pass and regression_pass
+    return {
+        "b16_n1000_upper95_by_payload": target,
+        "b16_n1000_limit": 1.0,
+        "b16_n1000_pass": target_pass,
+        "non_restorative_best_upper95": min(application) if application else None,
+        "non_restorative_limit": 0.90,
+        "non_restorative_pass": application_pass,
+        "all_supported_limit": 1.10,
+        "all_supported_worst_upper95": max(
+            (row["ratio_95_high"] for row in supported), default=None
+        ),
+        "all_supported_pass": regression_pass,
+        "decision": "ACCEPTED" if accepted else "REJECTED",
+    }
+
+
+def run_matrix(
+    *,
+    backend: str = "py_boundary",
+    samples: int = MINIMUM_SAMPLES,
+    interval_counts: Sequence[int] = INTERVAL_COUNTS,
+    batch_sizes: Sequence[int] = BATCH_SIZES,
+    payload_kinds: Sequence[str] = PAYLOAD_KINDS,
+    trace_kinds: Sequence[str] = TRACE_KINDS,
+) -> dict[str, Any]:
+    if backend != BACKEND:
+        raise ValueError(f"transaction experiment backend must be {BACKEND!r}")
+    if type(samples) is not int or samples < MINIMUM_SAMPLES:
+        raise ValueError(f"samples must be an integer >= {MINIMUM_SAMPLES}")
+    dimensions = (
+        tuple(interval_counts),
+        tuple(batch_sizes),
+        tuple(payload_kinds),
+        tuple(trace_kinds),
+    )
+    full_dimensions = (INTERVAL_COUNTS, BATCH_SIZES, PAYLOAD_KINDS, TRACE_KINDS)
+    bounded_dimensions = ((64,), (0, 1, 4), PAYLOAD_KINDS, TRACE_KINDS)
+    if dimensions == full_dimensions:
+        profile = "full"
+    elif dimensions == bounded_dimensions:
+        profile = "bounded"
+    else:
+        raise ValueError(
+            "transaction matrix must use the fixed full or bounded profile"
+        )
+    rows = [
+        _measure_case(backend, n, b, payload, trace, samples)
+        for n in interval_counts
+        for b in batch_sizes
+        for payload in payload_kinds
+        for trace in trace_kinds
+    ]
+    return {
+        "schema": SCHEMA,
+        "samples": samples,
+        "matrix": {
+            "profile": profile,
+            "batch_sizes": list(batch_sizes),
+            "interval_counts": list(interval_counts),
+            "payloads": list(payload_kinds),
+            "traces": list(trace_kinds),
+            "paired_order": "AB/BA alternating",
+            "timed_boundary": "mutation calls only; setup and exact validation outside",
+        },
+        "rows": rows,
+        "gate": _gate(rows),
+        "provenance": _provenance(),
+    }
+
+
+def _markdown(report: dict[str, Any], json_digest: str) -> str:
+    gate = report["gate"]
+    lines = [
+        "# RangeSet transaction experiment",
+        "",
+        f"Decision: **{gate['decision']}**",
+        f"JSON SHA-256: `{json_digest}`",
+        "",
+        "| N | B | payload | trace | median ratio | upper 95% |",
+        "| ---: | ---: | --- | --- | ---: | ---: |",
+    ]
+    lines.extend(
+        f"| {row['interval_count']} | {row['batch_size']} | {row['payload']} | "
+        f"{row['trace']} | {row['ratio_median']:.4f} | {row['ratio_95_high']:.4f} |"
+        for row in report["rows"]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_artifacts(report: dict[str, Any], output: Path) -> tuple[Path, Path, Path]:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    encoded = (
+        json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    ).encode()
+    output.write_bytes(encoded)
+    digest = hashlib.sha256(encoded).hexdigest()
+    markdown = output.with_suffix(".md")
+    markdown.write_text(_markdown(report, digest))
+    checksum = Path(f"{output}.sha256")
+    checksum.write_text(f"{digest}  {output.name}\n")
+    return output, markdown, checksum
+
+
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ValueError(f"duplicate key: {key!r}")
+        result[key] = value
+    return result
+
+
+def _reject_nonfinite(value: str) -> None:
+    raise ValueError(f"non-finite number: {value}")
+
+
+def _finite_float(value: str) -> float:
+    parsed = float(value)
+    if not math.isfinite(parsed):
+        raise ValueError(f"non-finite number: {value}")
+    return parsed
+
+
+def _validate_finite(value: Any) -> None:
+    if type(value) is float and not math.isfinite(value):
+        raise ValueError("non-finite number")
+    if isinstance(value, dict):
+        for item in value.values():
+            _validate_finite(item)
+    elif isinstance(value, list):
+        for item in value:
+            _validate_finite(item)
+
+
+def _exact_json_equal(left: Any, right: Any) -> bool:
+    if type(left) is not type(right):
+        return False
+    if isinstance(left, dict):
+        return left.keys() == right.keys() and all(
+            _exact_json_equal(left[key], right[key]) for key in left
+        )
+    if isinstance(left, list):
+        return len(left) == len(right) and all(
+            _exact_json_equal(a, b) for a, b in zip(left, right, strict=True)
+        )
+    return bool(left == right)
+
+
+def _require_keys(value: Any, keys: set[str], label: str) -> dict[str, Any]:
+    if type(value) is not dict or set(value) != keys:
+        raise ValueError(f"{label} keys/type mismatch")
+    return value
+
+
+def _is_sha256(value: Any) -> bool:
+    return (
+        type(value) is str
+        and len(value) == 64
+        and all(character in "0123456789abcdef" for character in value)
+    )
+
+
+def _expected_case_digests(
+    backend: str, count: int, batch_size: int, payload: str, trace: str
+) -> tuple[str, str]:
+    ranges = _seed_ranges(backend, count, payload)
+    rows = _scalar(ranges, _trace(count, batch_size, payload, trace))
+    return (
+        _checksum(_freeze_results(rows)),
+        _checksum(_freeze_snapshot(ranges.snapshot())),
+    )
+
+
+def verify_artifacts(output: Path) -> dict[str, Any]:
+    encoded = output.read_bytes()
+    digest = hashlib.sha256(encoded).hexdigest()
+    expected_sidecar = f"{digest}  {output.name}\n"
+    if Path(f"{output}.sha256").read_text() != expected_sidecar:
+        raise ValueError("checksum mismatch")
+    report = json.loads(
+        encoded,
+        object_pairs_hook=_reject_duplicate_keys,
+        parse_constant=_reject_nonfinite,
+        parse_float=_finite_float,
+    )
+    _validate_finite(report)
+    _require_keys(
+        report,
+        {"schema", "samples", "matrix", "rows", "gate", "provenance"},
+        "report",
+    )
+    if report["schema"] != SCHEMA:
+        raise ValueError("schema mismatch")
+    samples = report["samples"]
+    if type(samples) is not int or samples < MINIMUM_SAMPLES:
+        raise ValueError("invalid sample count/type")
+    matrix = _require_keys(
+        report["matrix"],
+        {
+            "profile",
+            "batch_sizes",
+            "interval_counts",
+            "payloads",
+            "traces",
+            "paired_order",
+            "timed_boundary",
+        },
+        "matrix/methodology",
+    )
+    expected_dimensions = {
+        "full": {
+            "batch_sizes": list(BATCH_SIZES),
+            "interval_counts": list(INTERVAL_COUNTS),
+            "payloads": list(PAYLOAD_KINDS),
+            "traces": list(TRACE_KINDS),
+        },
+        "bounded": {
+            "batch_sizes": [0, 1, 4],
+            "interval_counts": [64],
+            "payloads": list(PAYLOAD_KINDS),
+            "traces": list(TRACE_KINDS),
+        },
+    }
+    if type(matrix["profile"]) is not str:
+        raise ValueError("matrix profile exact type mismatch")
+    dimensions = expected_dimensions.get(matrix["profile"])
+    if dimensions is None or any(
+        not _exact_json_equal(matrix[key], value) for key, value in dimensions.items()
+    ):
+        raise ValueError("fixed matrix membership mismatch")
+    if (
+        matrix["paired_order"] != "AB/BA alternating"
+        or matrix["timed_boundary"]
+        != "mutation calls only; setup and exact validation outside"
+    ):
+        raise ValueError("fixed matrix methodology mismatch")
+    expected_identities = [
+        (n, b, payload, trace)
+        for n in matrix["interval_counts"]
+        for b in matrix["batch_sizes"]
+        for payload in matrix["payloads"]
+        for trace in matrix["traces"]
+    ]
+    rows = report["rows"]
+    if type(rows) is not list or len(rows) != len(expected_identities):
+        raise ValueError("row matrix shape mismatch")
+    row_keys = {
+        "backend",
+        "interval_count",
+        "batch_size",
+        "payload",
+        "trace",
+        "scalar_ns_samples",
+        "transaction_ns_samples",
+        "paired_ratios",
+        "ratio_median",
+        "ratio_95_low",
+        "ratio_95_high",
+        "transaction_peak_bytes_samples",
+        "stage_ns_samples",
+        "backend_load_ns_samples",
+        "prepublish_total_ns_samples",
+        "result_sha256",
+        "final_state_sha256",
+    }
+    observed_identities = []
+    for row in rows:
+        _require_keys(row, row_keys, "row")
+        if (
+            type(row["interval_count"]) is not int
+            or type(row["batch_size"]) is not int
+            or type(row["backend"]) is not str
+            or type(row["payload"]) is not str
+            or type(row["trace"]) is not str
+        ):
+            raise ValueError("row identity exact type mismatch")
+        identity = (
+            row["interval_count"],
+            row["batch_size"],
+            row["payload"],
+            row["trace"],
+        )
+        observed_identities.append(identity)
+        if row["backend"] != BACKEND:
+            raise ValueError("row backend identity mismatch")
+        integer_sample_keys = (
+            "scalar_ns_samples",
+            "transaction_ns_samples",
+            "transaction_peak_bytes_samples",
+            "stage_ns_samples",
+            "backend_load_ns_samples",
+            "prepublish_total_ns_samples",
+        )
+        for key in (*integer_sample_keys, "paired_ratios"):
+            values = row[key]
+            if type(values) is not list or len(values) != samples:
+                raise ValueError("raw sample shape mismatch")
+        if any(
+            type(value) is not int or value < 0
+            for key in integer_sample_keys
+            for value in row[key]
+        ) or any(
+            value <= 0
+            for key in ("scalar_ns_samples", "transaction_ns_samples")
+            for value in row[key]
+        ):
+            raise ValueError("elapsed/resource sample exact type mismatch")
+        for load, stage, total, elapsed in zip(
+            row["backend_load_ns_samples"],
+            row["stage_ns_samples"],
+            row["prepublish_total_ns_samples"],
+            row["transaction_ns_samples"],
+            strict=True,
+        ):
+            if not (load <= stage <= total <= elapsed):
+                raise ValueError("transaction timing components are inconsistent")
+        ratios = [
+            transaction / max(1, scalar)
+            for scalar, transaction in zip(
+                row["scalar_ns_samples"], row["transaction_ns_samples"], strict=True
+            )
+        ]
+        if not _exact_json_equal(ratios, row["paired_ratios"]):
+            raise ValueError("raw paired ratios mismatch")
+        low, high = _bootstrap_interval(
+            ratios,
+            BOOTSTRAP_SEED
+            + row["interval_count"]
+            + row["batch_size"]
+            + sum(map(ord, row["payload"] + row["trace"])),
+        )
+        derived = (statistics.median(ratios), low, high)
+        recorded = (row["ratio_median"], row["ratio_95_low"], row["ratio_95_high"])
+        if not _exact_json_equal(list(derived), list(recorded)):
+            raise ValueError("derived interval mismatch")
+        if any(
+            type(value) is not float or not math.isfinite(value)
+            for value in row["paired_ratios"]
+        ):
+            raise ValueError("ratio exact type/non-finite mismatch")
+        expected_result, expected_final = _expected_case_digests(
+            row["backend"], *identity
+        )
+        if row["result_sha256"] != expected_result:
+            raise ValueError("result digest mismatch")
+        if row["final_state_sha256"] != expected_final:
+            raise ValueError("final-state digest mismatch")
+    if not _exact_json_equal(
+        [list(identity) for identity in observed_identities],
+        [list(identity) for identity in expected_identities],
+    ):
+        raise ValueError("fixed matrix membership/order mismatch")
+    _require_keys(
+        report["gate"],
+        {
+            "b16_n1000_upper95_by_payload",
+            "b16_n1000_limit",
+            "b16_n1000_pass",
+            "non_restorative_best_upper95",
+            "non_restorative_limit",
+            "non_restorative_pass",
+            "all_supported_limit",
+            "all_supported_worst_upper95",
+            "all_supported_pass",
+            "decision",
+        },
+        "gate",
+    )
+    expected_gate = _gate(rows)
+    if not _exact_json_equal(report["gate"], expected_gate):
+        raise ValueError("gate mismatch")
+    provenance = _require_keys(
+        report["provenance"],
+        {"git", "sources", "runtime", "build", "backend"},
+        "provenance",
+    )
+    _require_keys(
+        provenance["git"],
+        {
+            "commit",
+            "head_tree",
+            "clean_worktree",
+            "changed_paths",
+            "staged_files",
+            "source_state_sha256",
+        },
+        "git provenance",
+    )
+    if not _exact_json_equal(provenance["git"], _git_metadata()):
+        raise ValueError("git/source-state provenance mismatch")
+    expected_sources = [
+        _file_provenance("tests/performance/experiments/rangeset_transaction.py"),
+        _file_provenance("treemendous/rangeset.py"),
+    ]
+    if not _exact_json_equal(provenance["sources"], expected_sources):
+        raise ValueError("source provenance path/hash mismatch")
+    if not _exact_json_equal(provenance["runtime"], _runtime_provenance()):
+        raise ValueError("runtime provenance does not match current runtime")
+    if not _exact_json_equal(provenance["build"], _build_provenance()):
+        raise ValueError("build provenance does not match current build")
+    if not _exact_json_equal(provenance["backend"], _binary_provenance()):
+        raise ValueError("active backend identity/module/type/path/hash mismatch")
+    if output.with_suffix(".md").read_text() != _markdown(report, digest):
+        raise ValueError("Markdown mismatch")
+    canonical = (
+        json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    ).encode()
+    if canonical != encoded:
+        raise ValueError("JSON is not canonical")
+    return report
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--backend", default="py_boundary")
+    parser.add_argument("--samples", type=int, default=MINIMUM_SAMPLES)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--verify", action="store_true")
+    parser.add_argument(
+        "--bounded", action="store_true", help="N=64, B=0/1/4 correctness slice"
+    )
+    args = parser.parse_args(argv)
+    if args.verify:
+        report = verify_artifacts(args.output)
+    else:
+        report = run_matrix(
+            backend=args.backend,
+            samples=args.samples,
+            interval_counts=(64,) if args.bounded else INTERVAL_COUNTS,
+            batch_sizes=(0, 1, 4) if args.bounded else BATCH_SIZES,
+        )
+        write_artifacts(report, args.output)
+        verify_artifacts(args.output)
+    print(
+        json.dumps(
+            {"artifact": str(args.output), "decision": report["gate"]["decision"]},
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/performance/experiments/test_application_backend_matrix.py
+++ b/tests/performance/experiments/test_application_backend_matrix.py
@@ -1,0 +1,197 @@
+"""Focused contracts for the concrete application backend experiment."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.performance.experiments import application_backend_matrix as experiment
+from treemendous.backends.registry import BackendRegistry
+
+
+def _rewrite(output: Path, report: dict[str, Any] | str) -> None:
+    text = (
+        report
+        if isinstance(report, str)
+        else json.dumps(report, indent=2, sort_keys=True) + "\n"
+    )
+    encoded = text.encode()
+    output.write_bytes(encoded)
+    digest = hashlib.sha256(encoded).hexdigest()
+    Path(f"{output}.sha256").write_text(f"{digest}  {output.name}\n")
+
+
+def test_all_qualified_backends_match_exact_application_evidence_and_factories() -> (
+    None
+):
+    registry = BackendRegistry.discover()
+    specs = experiment._eligible_specs(registry)
+    rows, _ = experiment._correctness_rows(registry, specs, experiment.ENGINE_NAMES)
+
+    assert {row["backend"] for row in rows} == {spec.id for spec in specs}
+    expected_calls = {
+        "contiguous_allocator": 2,
+        "disk_block_allocator": 2,
+        "pool_group": 8,
+        "claim_ledger": 14,
+        "partition_runtime": 22,
+    }
+    baseline = {
+        row["engine"]: row["semantic"]
+        for row in rows
+        if row["backend"] == experiment.BASELINE_BACKEND
+    }
+    for row in rows:
+        assert row["semantic"] == baseline[row["engine"]]
+        assert row["semantic_sha256"] == row["baseline_sha256"]
+        assert row["factory"]["calls"] == expected_calls[row["engine"]]
+        assert (
+            len(set(row["factory"]["implementation_ids"]))
+            == expected_calls[row["engine"]]
+        )
+
+
+def test_negative_requests_fail_closed_without_fallback() -> None:
+    rows = experiment._negative_evidence(BackendRegistry.discover())
+
+    assert [row["case"] for row in rows] == [
+        "unknown",
+        "unavailable",
+        "invalid",
+        "experimental",
+        "32-bit",
+        "nondeterministic",
+    ]
+    assert all(row["accepted"] is False for row in rows)
+    assert all(row["fallback_backend"] is None for row in rows)
+    for case in ("experimental", "32-bit", "nondeterministic"):
+        row = next(item for item in rows if item["case"] == case)
+        expected = {
+            "experimental": "experimental",
+            "32-bit": "signed 64-bit",
+            "nondeterministic": "nondeterministic",
+        }[case]
+        assert expected in row["reason"]
+
+
+@pytest.fixture(scope="module")
+def focused_report() -> dict[str, Any]:
+    return experiment.run_matrix(
+        blocks=experiment.MINIMUM_BLOCKS,
+        backend_ids=(experiment.BASELINE_BACKEND,),
+    )
+
+
+def test_bounded_balanced_matrix_and_strict_triplet(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output = tmp_path / "application-backends.json"
+    paths = experiment.write_artifacts(focused_report, output)
+    verified = experiment.verify_artifacts(output)
+
+    assert verified == focused_report
+    assert verified["gate"]["runtime_injection_retained"] is False
+    assert len(verified["benchmarks"]) == len(experiment.ENGINE_NAMES)
+    for row in verified["benchmarks"]:
+        assert row["validated_blocks"] == experiment.MINIMUM_BLOCKS
+        assert len(row["blocks"]) == experiment.MINIMUM_BLOCKS
+        assert [block["order"] for block in row["blocks"][:2]] == [
+            ["candidate", "baseline"],
+            ["baseline", "candidate"],
+        ]
+    assert all(path.is_file() for path in paths)
+
+
+def test_verifier_rejects_duplicate_nonfinite_and_exact_type_tamper(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output = tmp_path / "application-backends.json"
+    experiment.write_artifacts(focused_report, output)
+
+    duplicate = output.read_text().replace(
+        f'  "schema": "{experiment.SCHEMA}"',
+        f'  "schema": "duplicate",\n  "schema": "{experiment.SCHEMA}"',
+    )
+    _rewrite(output, duplicate)
+    with pytest.raises(ValueError, match="duplicate key"):
+        experiment.verify_artifacts(output)
+
+    nonfinite = copy.deepcopy(focused_report)
+    nonfinite["benchmarks"][0]["blocks"][0]["ratio"] = float("nan")
+    _rewrite(output, json.dumps(nonfinite, indent=2, sort_keys=True) + "\n")
+    with pytest.raises(ValueError, match="non-finite"):
+        experiment.verify_artifacts(output)
+
+    wrong_type = copy.deepcopy(focused_report)
+    wrong_type["benchmarks"][0]["blocks"][0]["candidate_ns"] = True
+    experiment.write_artifacts(wrong_type, output)
+    with pytest.raises(ValueError, match="duration exact type"):
+        experiment.verify_artifacts(output)
+
+
+def test_verifier_rejects_duplicate_correctness_benchmark_and_confirmation_rows(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output = tmp_path / "application-backends.json"
+
+    correctness = copy.deepcopy(focused_report)
+    correctness["correctness"].insert(1, copy.deepcopy(correctness["correctness"][0]))
+    correctness["correctness"].pop()
+    experiment.write_artifacts(correctness, output)
+    with pytest.raises(ValueError, match="correctness matrix order/uniqueness"):
+        experiment.verify_artifacts(output)
+
+    benchmark = copy.deepcopy(focused_report)
+    benchmark["benchmarks"].insert(1, copy.deepcopy(benchmark["benchmarks"][0]))
+    benchmark["benchmarks"].pop()
+    experiment.write_artifacts(benchmark, output)
+    with pytest.raises(ValueError, match="benchmark matrix order/uniqueness"):
+        experiment.verify_artifacts(output)
+
+    confirmation = copy.deepcopy(focused_report)
+    duplicate = copy.deepcopy(confirmation["benchmarks"][0])
+    duplicate["phase"] = "confirmation"
+    confirmation["confirmation"] = [duplicate, copy.deepcopy(duplicate)]
+    experiment.write_artifacts(confirmation, output)
+    with pytest.raises(ValueError, match="confirmation matrix order/uniqueness"):
+        experiment.verify_artifacts(output)
+
+
+def test_verifier_recomputes_ratios_gate_factory_and_provenance(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output = tmp_path / "application-backends.json"
+
+    wrong_ratio = copy.deepcopy(focused_report)
+    wrong_ratio["benchmarks"][0]["ratio"]["median_95_high"] += 0.01
+    experiment.write_artifacts(wrong_ratio, output)
+    with pytest.raises(ValueError, match="derived ratio interval"):
+        experiment.verify_artifacts(output)
+
+    wrong_gate = copy.deepcopy(focused_report)
+    wrong_gate["gate"]["runtime_injection_retained"] = True
+    experiment.write_artifacts(wrong_gate, output)
+    with pytest.raises(ValueError, match="recomputed gate"):
+        experiment.verify_artifacts(output)
+
+    wrong_factory = copy.deepcopy(focused_report)
+    wrong_factory["correctness"][0]["factory"]["calls"] += 1
+    experiment.write_artifacts(wrong_factory, output)
+    with pytest.raises(ValueError, match="factory call/identity"):
+        experiment.verify_artifacts(output)
+
+    wrong_source = copy.deepcopy(focused_report)
+    wrong_source["provenance"]["sources"][0]["sha256"] = "0" * 64
+    experiment.write_artifacts(wrong_source, output)
+    with pytest.raises(ValueError, match="provenance"):
+        experiment.verify_artifacts(output)
+
+    experiment.write_artifacts(focused_report, output)
+    output.with_suffix(".md").write_text("unbound\n")
+    with pytest.raises(ValueError, match="Markdown mismatch"):
+        experiment.verify_artifacts(output)

--- a/tests/performance/experiments/test_exact_batch_application_matrix.py
+++ b/tests/performance/experiments/test_exact_batch_application_matrix.py
@@ -1,0 +1,380 @@
+"""Focused contracts for the bounded exact-batch application diagnostic."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.performance.experiments import exact_batch_application_matrix as matrix
+
+
+def test_local_matrix_covers_fixed_states_batches_localities_and_shapes() -> None:
+    cases = matrix._cases(
+        matrix.LOCAL_INTERVAL_COUNTS,
+        matrix.BATCH_SIZES,
+        matrix.SHAPES,
+        matrix.LOCALITIES,
+    )
+    assert len(cases) == 3 * 4 * 5 * 3
+    assert {case.interval_count for case in cases} == {64, 1_000, 10_000}
+    assert {case.batch_size for case in cases} == {1, 4, 16, 64}
+    assert {case.locality for case in cases} == {"head", "middle", "tail"}
+    assert {case.shape for case in cases} == set(matrix.SHAPES)
+    assert matrix.case_definition(100_000, 16, "wide_fanout", "tail").fanout == 8
+
+
+@pytest.mark.parametrize("shape", matrix.SHAPES)
+@pytest.mark.parametrize("locality", matrix.LOCALITIES)
+@pytest.mark.parametrize("batch_size", (1, 4))
+def test_generated_application_shapes_match_cpp_boundary(
+    shape: str, locality: str, batch_size: int
+) -> None:
+    case = matrix.case_definition(64, batch_size, shape, locality)
+    rows, final_geometry, packed_bytes, work = matrix.attest_case(case)
+    assert len(rows) == batch_size
+    assert final_geometry
+    assert packed_bytes > 0
+    assert work["logical_rows"] == batch_size
+    assert work["initial_live_intervals"] == 64
+
+
+def test_shape_declarations_capture_rejections_noops_restore_and_fanout() -> None:
+    strict = matrix._oracle_evidence(
+        matrix.case_definition(64, 4, "strict_accept_reject", "middle")
+    )[2]
+    assert strict["strict_accepted_rows"] == 1
+    assert strict["strict_rejected_rows"] == 1
+
+    idempotent = matrix._oracle_evidence(
+        matrix.case_definition(64, 4, "idempotent_real_noop", "middle")
+    )[2]
+    assert idempotent["mutating_rows"] == 2
+    assert idempotent["noop_rows"] == 2
+    assert idempotent["initial_live_intervals"] == idempotent["final_live_intervals"]
+
+    for shape in ("fragment_restore", "coalesce_restore"):
+        work = matrix._oracle_evidence(matrix.case_definition(64, 4, shape, "middle"))[
+            2
+        ]
+        assert work["mutating_rows"] == 4
+        assert work["initial_live_intervals"] == work["final_live_intervals"]
+
+    wide_case = matrix.case_definition(64, 1, "wide_fanout", "middle")
+    wide_rows, _, wide_work = matrix._oracle_evidence(wide_case)
+    assert len(wide_rows[0].changed) == 8
+    assert wide_work["fanout"] == 8
+
+
+@pytest.fixture(scope="module")
+def focused_report() -> dict[str, Any]:
+    return matrix.run_benchmark(profile="smoke", samples=10)
+
+
+def _write_tampered_report(
+    tmp_path: Path, report: dict[str, Any]
+) -> tuple[Path, dict[str, Any]]:
+    output = tmp_path / "matrix.json"
+    tampered = copy.deepcopy(report)
+    matrix.write_artifacts(tampered, output)
+    return output, tampered
+
+
+def _refresh_workload_digests(report: dict[str, Any]) -> None:
+    manifest = report["workload_manifest"]
+    case = manifest["cases"][0]
+    case["digest"] = matrix._checksum(
+        {key: value for key, value in case.items() if key != "digest"}
+    )
+    manifest["digest"] = matrix._checksum(
+        {key: value for key, value in manifest.items() if key != "digest"}
+    )
+
+
+def _rewrite_json_and_checksum(output: Path, text: str) -> None:
+    encoded = text.encode()
+    output.write_bytes(encoded)
+    digest = hashlib.sha256(encoded).hexdigest()
+    Path(f"{output}.sha256").write_text(f"{digest}  {output.name}\n")
+
+
+def test_small_matrix_writes_and_verifies_canonical_triplet(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output = tmp_path / "matrix.json"
+    json_path, markdown_path, checksum_path = matrix.write_artifacts(
+        focused_report, output
+    )
+    verified = matrix.verify_artifacts(output)
+    before = tuple(
+        path.read_bytes() for path in (json_path, markdown_path, checksum_path)
+    )
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tests.performance.experiments.exact_batch_application_matrix",
+            "--verify",
+            "--output",
+            str(output),
+        ],
+        cwd=matrix._REPOSITORY_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert verified["schema"] == matrix.SCHEMA
+    assert len(verified["rows"][0]["exact_latency_ns_samples"]) == 10
+    assert all(path.is_file() for path in (json_path, markdown_path, checksum_path))
+    assert (
+        tuple(path.read_bytes() for path in (json_path, markdown_path, checksum_path))
+        == before
+    )
+
+
+def test_verify_rejects_duplicate_json_keys(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output, _ = _write_tampered_report(tmp_path, focused_report)
+    text = output.read_text().replace(
+        f'  "schema": "{matrix.SCHEMA}"',
+        f'  "schema": "duplicate",\n  "schema": "{matrix.SCHEMA}"',
+        1,
+    )
+    _rewrite_json_and_checksum(output, text)
+
+    with pytest.raises(ValueError, match="duplicate key"):
+        matrix.verify_artifacts(output)
+
+
+@pytest.mark.parametrize(
+    ("constant", "value"),
+    (("NaN", float("nan")), ("Infinity", float("inf")), ("-Infinity", -float("inf"))),
+)
+def test_verify_rejects_non_finite_json_numbers(
+    tmp_path: Path,
+    focused_report: dict[str, Any],
+    constant: str,
+    value: float,
+) -> None:
+    output, tampered = _write_tampered_report(tmp_path, focused_report)
+    tampered["rows"][0]["exact_latency_ns_samples"][0] = value
+    text = json.dumps(tampered, indent=2, sort_keys=True) + "\n"
+    assert constant in text
+    _rewrite_json_and_checksum(output, text)
+
+    with pytest.raises(ValueError, match="non-finite number"):
+        matrix.verify_artifacts(output)
+
+
+def test_verify_rejects_finite_syntax_that_overflows_json_float(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output, tampered = _write_tampered_report(tmp_path, focused_report)
+    tampered["rows"][0]["exact_latency_ns_samples"][0] = float("inf")
+    text = (json.dumps(tampered, indent=2, sort_keys=True) + "\n").replace(
+        "Infinity", "1e999", 1
+    )
+    _rewrite_json_and_checksum(output, text)
+
+    with pytest.raises(ValueError, match="non-finite number"):
+        matrix.verify_artifacts(output)
+
+
+@pytest.mark.parametrize(
+    "replacement",
+    (pytest.param(True, id="bool-int"), pytest.param(1.0, id="int-float")),
+)
+def test_verify_rejects_json_numeric_type_coercion_in_reconstructed_manifest(
+    tmp_path: Path,
+    focused_report: dict[str, Any],
+    replacement: bool | float,
+) -> None:
+    output, tampered = _write_tampered_report(tmp_path, focused_report)
+    tampered["workload_manifest"]["cases"][0]["work"]["fanout"] = replacement
+    _refresh_workload_digests(tampered)
+    matrix.write_artifacts(tampered, output)
+
+    with pytest.raises(ValueError, match="reconstructed matrix"):
+        matrix.verify_artifacts(output)
+
+
+def test_verify_rejects_checksum_tamper(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output, _ = _write_tampered_report(tmp_path, focused_report)
+    Path(f"{output}.sha256").write_text(f"{'0' * 64}  {output.name}\n")
+
+    with pytest.raises(ValueError, match="checksum"):
+        matrix.verify_artifacts(output)
+
+
+def test_verify_rejects_markdown_tamper(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output, _ = _write_tampered_report(tmp_path, focused_report)
+    output.with_suffix(".md").write_text("tampered\n")
+
+    with pytest.raises(ValueError, match="Markdown"):
+        matrix.verify_artifacts(output)
+
+
+def test_verify_rejects_raw_sample_tamper(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output, tampered = _write_tampered_report(tmp_path, focused_report)
+    tampered["rows"][0]["exact_latency_ns_samples"][0] += 1
+    matrix.write_artifacts(tampered, output)
+
+    with pytest.raises(ValueError, match="raw samples"):
+        matrix.verify_artifacts(output)
+
+
+def test_verify_rejects_derived_value_tamper(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output, tampered = _write_tampered_report(tmp_path, focused_report)
+    tampered["rows"][0]["paired_exact_over_scalar_median"] += 1.0
+    matrix.write_artifacts(tampered, output)
+
+    with pytest.raises(ValueError, match="paired_exact_over_scalar_median"):
+        matrix.verify_artifacts(output)
+
+
+def test_verify_rejects_workload_digest_tamper(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output, tampered = _write_tampered_report(tmp_path, focused_report)
+    tampered["workload_manifest"]["digest"] = "0" * 64
+    matrix.write_artifacts(tampered, output)
+
+    with pytest.raises(ValueError, match="workload digest"):
+        matrix.verify_artifacts(output)
+
+
+def test_git_metadata_binds_untracked_sources_and_reports_staged_files(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    tracked = tmp_path / "tracked.py"
+    tracked.write_text("VALUE = 1\n")
+    subprocess.run(["git", "add", "tracked.py"], cwd=tmp_path, check=True)
+    subprocess.run(
+        [
+            "git",
+            "-c",
+            "user.name=Test",
+            "-c",
+            "user.email=test@example.invalid",
+            "commit",
+            "-qm",
+            "initial",
+        ],
+        cwd=tmp_path,
+        check=True,
+    )
+    experiment = tmp_path / "tests/performance/experiments/new.py"
+    example = tmp_path / "examples/patterns/new.py"
+    experiment.parent.mkdir(parents=True)
+    example.parent.mkdir(parents=True)
+    experiment.write_text("EXPERIMENT = 1\n")
+    example.write_text("EXAMPLE = 1\n")
+    tracked.write_text("VALUE = 2\n")
+    subprocess.run(["git", "add", "tracked.py"], cwd=tmp_path, check=True)
+    monkeypatch.setattr(matrix, "_REPOSITORY_ROOT", tmp_path)
+
+    first = matrix._git_metadata()
+    assert first["staged_files"] == ["tracked.py"]
+    assert "tests/performance/experiments/new.py" in first["changed_paths"]
+    assert "examples/patterns/new.py" in first["changed_paths"]
+
+    experiment.write_text("EXPERIMENT = 2\n")
+    second = matrix._git_metadata()
+    assert first["source_state_sha256"] != second["source_state_sha256"]
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        ("runtime", "python_version"),
+        ("runtime", "python_implementation"),
+        ("runtime", "python_compiler"),
+        ("runtime", "platform"),
+        ("runtime", "machine"),
+        ("runtime", "architecture"),
+        ("build", "command"),
+        ("build", "cxx"),
+        ("build", "cxx_version"),
+        ("build", "cc"),
+        ("build", "cflags"),
+        ("build", "flags", "TREE_MENDOUS_WITH_ICL"),
+        ("backends", "exact_batch", "id"),
+        ("backends", "exact_batch", "module"),
+        ("backends", "exact_batch", "type"),
+        ("backends", "exact_batch", "extension", "path"),
+        ("backends", "exact_batch", "extension", "sha256"),
+    ),
+)
+def test_verify_rejects_each_runtime_build_and_backend_provenance_category(
+    tmp_path: Path, focused_report: dict[str, Any], path: tuple[str, ...]
+) -> None:
+    output, tampered = _write_tampered_report(tmp_path, focused_report)
+    target = tampered["provenance"]
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = True
+    matrix.write_artifacts(tampered, output)
+
+    with pytest.raises(ValueError, match="runtime|build|backend"):
+        matrix.verify_artifacts(output)
+
+
+def test_verify_rejects_packed_bytes_row_shape_method_and_provenance_tamper(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output = tmp_path / "matrix.json"
+
+    packed = copy.deepcopy(focused_report)
+    packed["rows"][0]["packed_result_bytes"] += 1
+    matrix.write_artifacts(packed, output)
+    with pytest.raises(ValueError, match="reconstructed workload"):
+        matrix.verify_artifacts(output)
+
+    extra = copy.deepcopy(focused_report)
+    extra["rows"][0]["extra"] = True
+    matrix.write_artifacts(extra, output)
+    with pytest.raises(ValueError, match="row keys/type"):
+        matrix.verify_artifacts(output)
+
+    missing = copy.deepcopy(focused_report)
+    del missing["rows"][0]["packed_result_bytes"]
+    text = json.dumps(missing, indent=2, sort_keys=True) + "\n"
+    _rewrite_json_and_checksum(output, text)
+    output.with_suffix(".md").write_text("unused\n")
+    with pytest.raises(ValueError, match="row keys/type"):
+        matrix.verify_artifacts(output)
+
+    method = copy.deepcopy(focused_report)
+    method["methodology"]["pair_order"] = "tampered"
+    matrix.write_artifacts(method, output)
+    with pytest.raises(ValueError, match="fixed methodology"):
+        matrix.verify_artifacts(output)
+
+    provenance = copy.deepcopy(focused_report)
+    provenance["provenance"]["sources"][0]["sha256"] = "0" * 64
+    matrix.write_artifacts(provenance, output)
+    with pytest.raises(ValueError, match="source file path/hash"):
+        matrix.verify_artifacts(output)
+
+    extension = copy.deepcopy(focused_report)
+    extension["provenance"]["backends"]["exact_batch"]["extension"]["sha256"] = "0" * 64
+    matrix.write_artifacts(extension, output)
+    with pytest.raises(ValueError, match="backend/extension provenance"):
+        matrix.verify_artifacts(output)

--- a/tests/performance/experiments/test_exact_batch_storage_matrix.py
+++ b/tests/performance/experiments/test_exact_batch_storage_matrix.py
@@ -1,0 +1,232 @@
+"""Strict contracts for segmented ExactBatch storage qualification evidence."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import math
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.performance.experiments import exact_batch_storage_matrix as matrix
+
+ARCHIVE = matrix._REPOSITORY_ROOT / "docs/evidence/experiments" / matrix.ARCHIVE_NAME
+
+# The 199 KB measured rejection artifact is reproducible evidence, not tracked
+# source. Reproduce it with `just reproduce-exact-batch-storage-rejection` (or
+# fetch the release asset) into docs/evidence/experiments to exercise the
+# archive-data contracts below. The durability proof itself—tracked patch plus
+# baseline/segmented source SHAs—runs unconditionally via
+# ``test_patch_applies_to_baseline_and_produces_archived_source_hash``.
+requires_archive = pytest.mark.skipif(
+    not ARCHIVE.is_file(),
+    reason="segmented rejection archive is reproducible/release evidence, not tracked",
+)
+
+
+@requires_archive
+def test_failed_small_n_confirmation_records_segmented_runtime_rejection() -> None:
+    report = matrix.verify_archive_artifacts(ARCHIVE)
+    rejection: dict[str, Any] = report["archive"]["rejection"]
+    assert rejection == {
+        "decision": "REJECTED",
+        "workload": "promotion-restorative-n64-b16",
+        "balanced_blocks": 20,
+        "candidate_over_vector_median": 1.0652732286470954,
+        "candidate_over_vector_confidence_95": [
+            1.0406022687634031,
+            1.1159159624697532,
+        ],
+        "upper95_gate": 1.10,
+    }
+    assert (
+        rejection["candidate_over_vector_confidence_95"][1] > rejection["upper95_gate"]
+    )
+
+
+def test_full_matrix_identity_covers_required_dimensions_and_block_boundaries() -> None:
+    definitions = matrix.diagnostic_definitions()
+    regular = [item for item in definitions if item["case_id"].startswith("matrix-")]
+    blocks = [item for item in definitions if item["case_id"].startswith("block-")]
+
+    assert len(regular) == 4 * 4 * 9
+    assert {item["interval_count"] for item in regular} == {64, 1_000, 10_000, 100_000}
+    assert {item["batch_size"] for item in regular} == {0, 1, 16, 256}
+    assert {item["shape"] for item in regular} == set(matrix.DIAGNOSTIC_SHAPES)
+    block_boundaries = {(item["interval_count"], item["shape"]) for item in blocks}
+    expected_boundaries = {
+        (count, f"block_{shape}")
+        for count in (matrix.K - 1, matrix.K, matrix.K + 1)
+        for shape in matrix.BLOCK_SHAPES
+    }
+    assert block_boundaries == expected_boundaries
+
+
+def test_promotion_matrix_has_every_fixed_gate_cell_and_separate_layers() -> None:
+    definitions = matrix.promotion_definitions()
+    ids = {item["case_id"] for item in definitions}
+    assert "promotion-restorative-n64-b16" in ids
+    assert "promotion-local-n100000-b16" in ids
+    wide_ids = {f"promotion-wide-n100000-p{value}" for value in (1, 10, 100)}
+    snapshot_ids = {f"promotion-snapshot-n{count}" for count in matrix.INTERVAL_COUNTS}
+    assert wide_ids <= ids
+    assert snapshot_ids <= ids
+    assert {item["layer"] for item in definitions} == {
+        "construction",
+        "mutate",
+        "snapshot",
+        "materialization",
+    }
+
+
+@requires_archive
+def test_archive_workers_record_distinct_roots_and_native_binaries() -> None:
+    report = matrix.verify_archive_artifacts(ARCHIVE)
+    block = report["balanced_blocks"][0]
+    baseline = block["baseline"]
+    candidate = block["candidate"]
+
+    assert Path(baseline["imports"]["treemendous"]["path"]).is_relative_to(
+        Path(baseline["root"])
+    )
+    assert Path(candidate["imports"]["treemendous"]["path"]).is_relative_to(
+        Path(candidate["root"])
+    )
+    assert baseline["root"] != candidate["root"]
+    assert baseline["binary"]["path"] != candidate["binary"]["path"]
+    assert baseline["binary"]["sha256"] != candidate["binary"]["sha256"]
+
+
+def test_worker_rejects_when_both_roots_resolve_to_candidate() -> None:
+    candidate_root = matrix._REPOSITORY_ROOT.resolve()
+    with pytest.raises(ValueError, match="same native binary path"):
+        matrix._run_worker(
+            candidate_root,
+            "promotion",
+            "smoke",
+            comparison_root=candidate_root,
+        )
+
+
+@pytest.fixture(scope="module")
+def smoke_artifact() -> tuple[Path, dict[str, Any]]:
+    if not ARCHIVE.is_file():
+        pytest.skip(
+            "segmented rejection archive is reproducible/release evidence, not tracked"
+        )
+    return ARCHIVE, matrix.verify_archive_artifacts(ARCHIVE)
+
+
+def _rewrite(output: Path, report: dict[str, Any]) -> None:
+    matrix.write_artifacts(report, output)
+
+
+def test_smoke_artifact_round_trips_strict_archive_verifier(
+    smoke_artifact: tuple[Path, dict[str, Any]],
+) -> None:
+    output, report = smoke_artifact
+    verified = matrix.verify_archive_artifacts(output)
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tests.performance.experiments.exact_batch_storage_matrix",
+            "--verify",
+            "--archive",
+            "--output",
+            str(output),
+        ],
+        cwd=matrix._REPOSITORY_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert verified["archive"]["rejection"]["decision"] == "REJECTED"
+    assert len(verified["balanced_blocks"]) == matrix.PROMOTION_BLOCKS
+    assert verified["promotion_rows"] == report["promotion_rows"]
+
+
+def test_patch_applies_to_baseline_and_produces_archived_source_hash() -> None:
+    matrix._verify_patch_application()
+
+
+def test_verifier_rejects_matrix_and_derived_tampering(
+    tmp_path: Path, smoke_artifact: tuple[Path, dict[str, Any]]
+) -> None:
+    _, report = smoke_artifact
+    output = tmp_path / matrix.ARCHIVE_NAME
+
+    identity = copy.deepcopy(report)
+    identity["matrix_identity"]["batch_sizes"] = [16]
+    _rewrite(output, identity)
+    with pytest.raises(ValueError, match="matrix identity"):
+        matrix.verify_archive_artifacts(output)
+
+    derived = copy.deepcopy(report)
+    derived["promotion_rows"][0]["candidate_over_vector_median"] += 0.25
+    _rewrite(output, derived)
+    with pytest.raises(ValueError, match="promotion raw derivation"):
+        matrix.verify_archive_artifacts(output)
+
+    duplicate = copy.deepcopy(report)
+    duplicate["balanced_blocks"][0]["candidate"]["cells"].insert(
+        1, copy.deepcopy(duplicate["balanced_blocks"][0]["candidate"]["cells"][0])
+    )
+    duplicate["balanced_blocks"][0]["candidate"]["cells"].pop()
+    _rewrite(output, duplicate)
+    with pytest.raises(ValueError, match="matrix order/uniqueness"):
+        matrix.verify_archive_artifacts(output)
+
+    oracle = copy.deepcopy(report)
+    oracle["balanced_blocks"][0]["candidate"]["cells"][0]["oracle_digest"] = "0" * 64
+    _rewrite(output, oracle)
+    with pytest.raises(ValueError, match="cell derivation"):
+        matrix.verify_archive_artifacts(output)
+
+
+def test_verifier_rejects_duplicate_keys_nonfinite_and_provenance_tampering(
+    tmp_path: Path, smoke_artifact: tuple[Path, dict[str, Any]]
+) -> None:
+    _, report = smoke_artifact
+    output = tmp_path / matrix.ARCHIVE_NAME
+
+    provenance = copy.deepcopy(report)
+    provenance["provenance"]["candidate"]["binary"]["sha256"] = "0" * 64
+    _rewrite(output, provenance)
+    with pytest.raises(ValueError, match="provenance|binary"):
+        matrix.verify_archive_artifacts(output)
+
+    patch = copy.deepcopy(report)
+    patch["archive"]["patch"]["sha256"] = "0" * 64
+    _rewrite(output, patch)
+    with pytest.raises(ValueError, match="patch/rejection binding"):
+        matrix.verify_archive_artifacts(output)
+
+    _rewrite(output, report)
+    text = output.read_text().replace(
+        f'  "schema": "{matrix.SCHEMA}"',
+        f'  "schema": "duplicate",\n  "schema": "{matrix.SCHEMA}"',
+        1,
+    )
+    encoded = text.encode()
+    output.write_bytes(encoded)
+    Path(f"{output}.sha256").write_text(
+        f"{hashlib.sha256(encoded).hexdigest()}  {output.name}\n"
+    )
+    with pytest.raises(ValueError, match="duplicate key"):
+        matrix.verify_archive_artifacts(output)
+
+    nonfinite = copy.deepcopy(report)
+    nonfinite["promotion_rows"][0]["candidate_over_vector_median"] = math.nan
+    encoded = (json.dumps(nonfinite, indent=2, sort_keys=True) + "\n").encode()
+    output.write_bytes(encoded)
+    Path(f"{output}.sha256").write_text(
+        f"{hashlib.sha256(encoded).hexdigest()}  {output.name}\n"
+    )
+    with pytest.raises(ValueError, match="non-finite"):
+        matrix.verify_archive_artifacts(output)

--- a/tests/performance/experiments/test_lease_state_scaling.py
+++ b/tests/performance/experiments/test_lease_state_scaling.py
@@ -1,0 +1,266 @@
+"""Focused contracts for the lease-state scaling experiment."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.performance.experiments import lease_state_scaling as experiment
+from treemendous.applications._shared.leasing import LeaseState
+from treemendous.domain import Span
+
+
+def _synthetic_row(kind: str, count: int, blocks: int) -> dict[str, Any]:
+    if kind == "no_expiry_acquire_release":
+        candidate_ns = count * 100
+        baseline_ns = count * 1_000
+        cycles = experiment.WRITE_CYCLES
+    else:
+        candidate_ns = 100
+        baseline_ns = 1_000
+        cycles = 1 if kind == "expiry_burst" else experiment.READ_CYCLES
+    raw_blocks = []
+    candidate_totals = []
+    baseline_totals = []
+    for block_index in range(blocks):
+        first = (
+            ["candidate", "baseline"]
+            if block_index % 2 == 0
+            else ["baseline", "candidate"]
+        )
+        positions = [
+            {
+                "first": ordering,
+                "candidate_ns": candidate_ns,
+                "baseline_ns": baseline_ns,
+            }
+            for ordering in first
+        ]
+        candidate_total = candidate_ns * 2
+        baseline_total = baseline_ns * 2
+        raw_blocks.append(
+            {
+                "block_index": block_index,
+                "positions": positions,
+                "candidate_ns_total": candidate_total,
+                "baseline_ns_total": baseline_total,
+                "ratio": candidate_total / baseline_total,
+            }
+        )
+        candidate_totals.append(candidate_total)
+        baseline_totals.append(baseline_total)
+    ratios = [
+        candidate / baseline
+        for candidate, baseline in zip(candidate_totals, baseline_totals, strict=True)
+    ]
+    seed = experiment.BOOTSTRAP_SEED + count * 17 + sum(map(ord, kind))
+    divisor = float(2 * cycles)
+    row = {
+        "kind": kind,
+        "active_leases": count,
+        "cycles_per_position": cycles,
+        "validated_blocks": blocks,
+        "blocks": raw_blocks,
+        "block_ratios": ratios,
+        "candidate_ns_per_cycle": experiment._summary(
+            [value / divisor for value in candidate_totals], seed + 1
+        ),
+        "baseline_ns_per_cycle": experiment._summary(
+            [value / divisor for value in baseline_totals], seed + 2
+        ),
+        "ratio": experiment._summary(ratios, seed),
+        "result_sha256": experiment._semantic_digests(kind, count)[0],
+        "final_state_sha256": experiment._semantic_digests(kind, count)[1],
+    }
+    if kind == "no_expiry_acquire_release":
+        row.update(
+            {
+                "candidate_active_lease_replays": 0,
+                "baseline_active_lease_replays": count * blocks * 4,
+            }
+        )
+    elif kind == "expiry_burst":
+        row["expired_per_cycle"] = max(1, count // 8)
+    elif kind == "fence_validation":
+        row["baseline_linear_lease_visits"] = (
+            count * blocks * 2 * experiment.READ_CYCLES
+        )
+    return row
+
+
+def _synthetic_report() -> dict[str, Any]:
+    blocks = experiment.SMOKE_BLOCKS
+    rows = [
+        _synthetic_row(kind, count, blocks)
+        for count in experiment.ACTIVE_LEASES
+        for kind in (
+            "repeated_snapshot",
+            "fence_validation",
+            "no_expiry_acquire_release",
+            "expiry_burst",
+        )
+    ]
+    instrumentation = {"public_snapshot_calls": 0, "linear_lease_scans": 0}
+    memory = {
+        "restorative_cycles": 1_000,
+        "bytes_after_100": 1_000,
+        "bytes_after_1000": 1_000,
+        "settling_ratio": 1.0,
+        "limit": experiment.MEMORY_SETTLING_LIMIT,
+    }
+    return {
+        "schema": experiment.SCHEMA,
+        "blocks": blocks,
+        "methodology": experiment._methodology(blocks),
+        "instrumentation": instrumentation,
+        "rows": rows,
+        "memory": memory,
+        "gate": experiment._gate(rows, instrumentation, memory),
+        "provenance": experiment._provenance(),
+    }
+
+
+def test_experiment_only_candidate_clones_free_state_without_runtime_seam() -> None:
+    pool, _, _ = experiment._seed_pool(32)
+    replays = [0]
+    experiment._observe_active_replays(pool, replays)
+    target = Span(32, 33)
+
+    acquired = experiment._candidate_acquire_exact(pool, "candidate", target)
+    released = experiment._candidate_release(pool, acquired)
+
+    assert acquired.resource == target
+    assert released.state is LeaseState.RELEASED
+    assert replays == [0]
+    assert pool.snapshot().diagnostics.active_leases == 32
+    assert not hasattr(pool, "_clone_free")
+
+
+def _write(output: Path, report: dict[str, Any]) -> None:
+    experiment.write_artifacts(report, output)
+
+
+def test_verifier_rejects_matrix_schema_type_digest_and_derived_tampering(
+    tmp_path: Path,
+) -> None:
+    report = _synthetic_report()
+    output = tmp_path / "lease.json"
+
+    duplicate = copy.deepcopy(report)
+    duplicate["rows"].insert(1, copy.deepcopy(duplicate["rows"][0]))
+    duplicate["rows"].pop()
+    _write(output, duplicate)
+    with pytest.raises(ValueError, match="ordered unique matrix"):
+        experiment.verify_artifacts(output)
+
+    missing = copy.deepcopy(report)
+    del missing["rows"][0]["final_state_sha256"]
+    _write(output, missing)
+    with pytest.raises(ValueError, match="per-kind row schema"):
+        experiment.verify_artifacts(output)
+
+    relabeled = copy.deepcopy(report)
+    relabeled["rows"][0]["kind"] = "fence_validation"
+    _write(output, relabeled)
+    with pytest.raises(ValueError, match="ordered unique matrix"):
+        experiment.verify_artifacts(output)
+
+    bool_int = copy.deepcopy(report)
+    bool_int["rows"][0]["active_leases"] = True
+    _write(output, bool_int)
+    with pytest.raises(ValueError, match="identity exact type"):
+        experiment.verify_artifacts(output)
+
+    semantic = copy.deepcopy(report)
+    semantic["rows"][0]["result_sha256"] = "0" * 64
+    _write(output, semantic)
+    with pytest.raises(ValueError, match="semantic digest"):
+        experiment.verify_artifacts(output)
+
+    instrumentation = copy.deepcopy(report)
+    instrumentation["rows"][1]["baseline_linear_lease_visits"] += 1
+    _write(output, instrumentation)
+    with pytest.raises(ValueError, match="fence instrumentation"):
+        experiment.verify_artifacts(output)
+
+    root_instrumentation = copy.deepcopy(report)
+    root_instrumentation["instrumentation"]["public_snapshot_calls"] = 1
+    _write(output, root_instrumentation)
+    with pytest.raises(ValueError, match="instrumentation derivation"):
+        experiment.verify_artifacts(output)
+
+    memory = copy.deepcopy(report)
+    memory["memory"]["settling_ratio"] = 1.01
+    _write(output, memory)
+    with pytest.raises(ValueError, match="memory derivation"):
+        experiment.verify_artifacts(output)
+
+
+def test_verifier_rejects_duplicate_key_and_noncanonical_bytes(tmp_path: Path) -> None:
+    report = _synthetic_report()
+    output = tmp_path / "lease.json"
+    _write(output, report)
+
+    duplicated = output.read_text().replace(
+        f'  "schema": "{experiment.SCHEMA}"',
+        f'  "schema": "duplicate",\n  "schema": "{experiment.SCHEMA}"',
+        1,
+    )
+    encoded = duplicated.encode()
+    output.write_bytes(encoded)
+    Path(f"{output}.sha256").write_text(
+        f"{hashlib.sha256(encoded).hexdigest()}  {output.name}\n"
+    )
+    with pytest.raises(ValueError, match="duplicate key"):
+        experiment.verify_artifacts(output)
+
+    noncanonical = json.dumps(report, sort_keys=True).encode()
+    output.write_bytes(noncanonical)
+    Path(f"{output}.sha256").write_text(
+        f"{hashlib.sha256(noncanonical).hexdigest()}  {output.name}\n"
+    )
+    with pytest.raises(ValueError, match="not canonical"):
+        experiment.verify_artifacts(output)
+
+
+def test_generation_then_separate_process_verify_is_byte_stable(
+    tmp_path: Path,
+) -> None:
+    report = _synthetic_report()
+    gate = report["gate"]
+    assert gate["candidate_b"]["decision"] == "ACCEPTED"
+    assert gate["candidate_d"]["decision"] == "REJECTED"
+    assert gate["candidate_d"]["checks"] == {
+        "no_expiry_zero_active_replays": True,
+        "no_expiry_n8192_upper_at_most_0_50": True,
+        "candidate_n8192_over_n2048_at_most_2": False,
+        "write_cells_upper_at_most_1_10": True,
+        "retained_memory_settles_within_10_percent": True,
+    }
+
+    output = tmp_path / "lease-state-scaling-smoke.json"
+    paths = experiment.write_artifacts(report, output)
+    before = tuple(path.read_bytes() for path in paths)
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "tests.performance.experiments.lease_state_scaling",
+            "--verify",
+            "--output",
+            str(output),
+        ],
+        cwd=experiment._ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+    assert tuple(path.read_bytes() for path in paths) == before

--- a/tests/performance/experiments/test_radio_spectrum_index_matrix.py
+++ b/tests/performance/experiments/test_radio_spectrum_index_matrix.py
@@ -1,0 +1,392 @@
+"""Focused contracts for the radio-spectrum index representation experiment."""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.performance.experiments import radio_spectrum_index_matrix as experiment
+from treemendous.applications.scheduling.radio_spectrum import RadioSpectrumScheduler
+from treemendous.multidimensional import BoxIndex
+
+
+def _rewrite(output: Path, report: dict[str, Any] | str) -> None:
+    text = (
+        report
+        if isinstance(report, str)
+        else json.dumps(report, indent=2, sort_keys=True, allow_nan=False) + "\n"
+    )
+    encoded = text.encode()
+    output.write_bytes(encoded)
+    digest = hashlib.sha256(encoded).hexdigest()
+    Path(f"{output}.sha256").write_text(f"{digest}  {output.name}\n")
+
+
+def test_private_empty_scheduler_injection_does_not_change_runtime_default() -> None:
+    stable = RadioSpectrumScheduler(experiment.CHANNEL_COUNT)
+    projected = experiment._new_scheduler(
+        "projection",
+        active_entries=32,
+        blocks=experiment.MINIMUM_BLOCKS,
+        scenario_count=1,
+    )
+
+    assert type(stable._index) is BoxIndex
+    assert stable._index.diagnostics().algorithm == "linear"
+    assert projected._index.diagnostics().algorithm == "axis_projection"
+    assert not stable._records and not projected._records
+
+
+def test_independent_oracle_covers_identity_conflicts_cancellation_and_state() -> None:
+    traces = [
+        experiment._semantic_trace(kind) for kind in ("linear", "projection", "grid")
+    ]
+
+    normalized = []
+    for trace in traces:
+        state = copy.deepcopy(trace["final_state"])
+        state["diagnostics"].update(
+            {
+                "algorithm": "normalized",
+                "projection_sizes": [],
+                "posting_count": None,
+                "occupied_cell_count": None,
+                "estimated_memory_bytes": None,
+            }
+        )
+        normalized.append(
+            {
+                "calls": trace["calls"],
+                "snapshot_order": trace["snapshot_order"],
+                "snapshot_version": trace["snapshot_version"],
+                "final_state": state,
+            }
+        )
+    assert normalized[0] == normalized[1] == normalized[2]
+    assert traces[0]["calls"][1]["same_identity"] is True
+    assert traces[0]["calls"][7]["same_identity"] is True
+    assert traces[0]["snapshot_version"] == 4
+
+
+def test_grid_guard_error_propagates_without_fallback_or_mutation() -> None:
+    evidence = experiment._grid_guard_adversary()
+
+    assert evidence["algorithm"] == "sparse_grid"
+    assert evidence["fallback"] is None
+    assert evidence["state_unchanged"] is True
+    assert "max_cells_per_query" in evidence["error"]["message"]
+    assert evidence["limits"]["max_cells_per_query"] == 64
+
+
+def test_density_and_axis_skew_change_seed_and_oracle_query_geometry() -> None:
+    base = experiment.SCENARIOS[0]
+    high_density = dataclasses.replace(base, density="high")
+    channel_skew = dataclasses.replace(base, axis_skew="channel")
+    assert experiment._seed_arguments(base, 40) != experiment._seed_arguments(
+        high_density, 40
+    )
+    assert experiment._seed_arguments(base, 40) != experiment._seed_arguments(
+        channel_skew, 40
+    )
+    low_oracle = experiment._seed_oracle(base, 128)
+    high_oracle = experiment._seed_oracle(high_density, 128)
+    low_query = low_oracle.conflicts_for(*experiment._query_arguments(base, 128, 40))
+    high_query = high_oracle.conflicts_for(
+        *experiment._query_arguments(high_density, 128, 40)
+    )
+    assert low_query is not None and high_query is not None
+    assert len(low_query[1]) == 1
+    assert len(high_query[1]) > len(low_query[1])
+
+    scenarios = experiment.SCENARIOS[:4]
+    seed_shapes = {
+        scenario.name: tuple(
+            tuple(
+                experiment._seed_arguments(scenario, index)[key]
+                for key in ("channel_start", "start", "end")
+            )
+            for index in (0, 40, 100)
+        )
+        for scenario in scenarios
+    }
+    assert len(set(seed_shapes.values())) == len(scenarios)
+
+    match_counts = {}
+    for scenario in scenarios:
+        oracle = experiment._seed_oracle(scenario, 128)
+        counts = []
+        for query_index in range(0, 112, 7):
+            arguments = experiment._query_arguments(scenario, 128, query_index)
+            conflict = oracle.conflicts_for(*arguments)
+            counts.append(0 if conflict is None else len(conflict[1]))
+        match_counts[scenario.name] = counts
+    assert set(match_counts["low-narrow-narrow"]) == {1}
+    assert min(match_counts["medium-broad-channel"]) > 1
+    assert min(match_counts["medium-broad-time"]) > 1
+    assert set(match_counts["high-broad-both"]) == {128}
+
+
+def test_mutation_mix_uses_distinct_reservations_and_separate_replay() -> None:
+    by_ratio = {
+        scenario.insertion_cancellation_ratio: scenario
+        for scenario in experiment.SCENARIOS
+    }
+    for ratio in ("3:1", "2:2", "1:3"):
+        setup, timed = experiment._commands(
+            by_ratio[ratio],
+            active_entries=128,
+            scenario_index=0,
+            block_index=0,
+            total_blocks=experiment.MINIMUM_BLOCKS,
+            seed=1,
+        )
+        reserve_calls = [
+            command for command in (*setup, *timed) if command[0] == "reserve"
+        ]
+        request_ids = [command[2]["request_id"] for command in reserve_calls]
+        assert len(request_ids) == len(set(request_ids))
+        cancellations = [command[1][1] for command in timed if command[0] == "cancel"]
+        assert len(cancellations) == len(set(cancellations))
+
+    replay = by_ratio["replay"]
+    assert replay.name == "idempotent-replay"
+    setup, timed = experiment._commands(
+        replay,
+        active_entries=128,
+        scenario_index=0,
+        block_index=0,
+        total_blocks=experiment.MINIMUM_BLOCKS,
+        seed=1,
+    )
+    assert len(setup) == 1
+    assert len({(command[1], tuple(command[2].items())) for command in timed[4:]}) == 1
+
+
+def _gate_evidence(
+    held_out_upper: float | None,
+) -> tuple[
+    list[dict[str, Any]], list[dict[str, Any]], list[dict[str, Any]], dict[str, Any]
+]:
+    scenario = experiment.SCENARIOS[0]
+
+    def row(phase: str, size: int, upper: float) -> dict[str, Any]:
+        return {
+            "phase": phase,
+            "candidate": "projection",
+            "scenario": {"name": scenario.name},
+            "active_entries": size,
+            "ratio": {"median_95_high": upper},
+        }
+
+    training = [row("training", 2_000, 0.75), row("training", 10_000, 0.75)]
+    held_out = (
+        [] if held_out_upper is None else [row("held_out", 5_000, held_out_upper)]
+    )
+    construction = [
+        {
+            "phase": item["phase"],
+            "candidate": item["candidate"],
+            "scenario": item["scenario"],
+            "active_entries": item["active_entries"],
+            "retained_memory_ratio": 1.0,
+        }
+        for item in [*training, *held_out]
+    ]
+    control = {"ratio": {"median_95_high": 1.0}}
+    return training, held_out, construction, control
+
+
+def test_gate_uses_lower_adjacent_size_and_requires_held_out_confirmation() -> None:
+    training, held_out, construction, control = _gate_evidence(0.95)
+    decision = experiment._gate(
+        training, held_out, construction, (2_000, 10_000), control
+    )
+    assert decision["decision"] == "REJECTED"
+    assert any(
+        "held-out selected cells failed" in reason
+        for reason in decision["rejected_reasons"]
+    )
+
+    training, held_out, construction, control = _gate_evidence(None)
+    decision = experiment._gate(
+        training, held_out, construction, (2_000, 10_000), control
+    )
+    assert decision["decision"] == "REJECTED"
+    assert any(
+        "lack predetermined held-out evidence" in reason
+        for reason in decision["rejected_reasons"]
+    )
+
+    training, held_out, construction, control = _gate_evidence(0.85)
+    decision = experiment._gate(
+        training, held_out, construction, (2_000, 10_000), control
+    )
+    assert decision["decision"] == "QUALIFIED_PRIVATE_CONFIRMATION_REQUIRED"
+    assert "projection:low-narrow-narrow:2000" in decision["selected_cells"]
+    assert "projection:low-narrow-narrow:5000" in decision["selected_cells"]
+
+    control["ratio"]["median_95_high"] = 1.11
+    decision = experiment._gate(
+        training, held_out, construction, (2_000, 10_000), control
+    )
+    assert decision["decision"] == "REJECTED"
+    assert decision["default_linear_upper_ratio"] == 1.11
+    assert any(
+        "explicitly patched linear control" in reason
+        for reason in decision["rejected_reasons"]
+    )
+
+
+@pytest.fixture(scope="module")
+def focused_report() -> dict[str, Any]:
+    return experiment.run_matrix(
+        profile="focused",
+        blocks=experiment.MINIMUM_BLOCKS,
+        training_sizes=experiment.TRAINING_SIZES[:2],
+        held_out_sizes=experiment.HELD_OUT_SIZES[:1],
+        scenarios=experiment.SCENARIOS[:1],
+        candidates=("projection",),
+    )
+
+
+def test_balanced_blocks_whole_block_bootstrap_and_rejected_runtime(
+    focused_report: dict[str, Any],
+) -> None:
+    assert focused_report["methodology"]["blocks_recorded_before_run"] == 25
+    assert focused_report["decision"]["decision"] == "REJECTED"
+    assert focused_report["decision"]["runtime_index"] == "linear"
+    assert focused_report["decision"]["runtime_seam_retained"] is False
+    assert focused_report["decision"]["live_migration"] is False
+    assert focused_report["decision"]["selected_cells"] == []
+    control = focused_report["default_linear_control"]
+    assert control["candidate"] == "default"
+    assert control["phase"] == "default_linear_control"
+    assert (
+        control["ratio"]["median_95_high"]
+        == focused_report["decision"]["default_linear_upper_ratio"]
+    )
+    assert control["ratio"]["median"] != 1.0
+    assert len(control["blocks"]) == experiment.MINIMUM_BLOCKS
+    for row in [*focused_report["training"], *focused_report["held_out"], control]:
+        assert row["validated_blocks"] == experiment.MINIMUM_BLOCKS
+        assert row["operations_per_position"] == experiment.OPERATIONS_PER_POSITION
+        assert [block["order"] for block in row["blocks"][:2]] == [
+            ["candidate", "baseline"],
+            ["baseline", "candidate"],
+        ]
+        expected_algorithm = "linear" if row is control else "axis_projection"
+        assert row["query_diagnostics"]["algorithm"] == expected_algorithm
+
+
+def test_canonical_triplet_and_strict_verifier(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output = tmp_path / "radio-spectrum.json"
+    paths = experiment.write_artifacts(focused_report, output)
+
+    assert experiment.verify_artifacts(output) == focused_report
+    assert all(path.is_file() for path in paths)
+    assert (
+        output.with_suffix(".md")
+        .read_text()
+        .startswith("# RadioSpectrumScheduler index representation experiment\n")
+    )
+
+
+def test_verifier_rejects_duplicate_nonfinite_exact_type_and_derived_tamper(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output = tmp_path / "radio-spectrum.json"
+
+    duplicate = (
+        json.dumps(focused_report, indent=2, sort_keys=True).replace(
+            f'  "schema": "{experiment.SCHEMA}"',
+            f'  "schema": "duplicate",\n  "schema": "{experiment.SCHEMA}"',
+        )
+        + "\n"
+    )
+    experiment.write_artifacts(focused_report, output)
+    _rewrite(output, duplicate)
+    with pytest.raises(ValueError, match="duplicate key"):
+        experiment.verify_artifacts(output)
+
+    nonfinite = copy.deepcopy(focused_report)
+    nonfinite["training"][0]["blocks"][0]["ratio"] = float("nan")
+    text = json.dumps(nonfinite, indent=2, sort_keys=True) + "\n"
+    _rewrite(output, text)
+    with pytest.raises(ValueError, match="non-finite"):
+        experiment.verify_artifacts(output)
+
+    wrong_type = copy.deepcopy(focused_report)
+    wrong_type["training"][0]["blocks"][0]["candidate_ns"] = True
+    experiment.write_artifacts(wrong_type, output)
+    with pytest.raises(ValueError, match="exact type"):
+        experiment.verify_artifacts(output)
+
+    wrong_ratio = copy.deepcopy(focused_report)
+    wrong_ratio["training"][0]["ratio"]["median_95_high"] += 0.01
+    experiment.write_artifacts(wrong_ratio, output)
+    with pytest.raises(ValueError, match="derived ratio"):
+        experiment.verify_artifacts(output)
+
+    wrong_decision = copy.deepcopy(focused_report)
+    wrong_decision["decision"]["runtime_seam_retained"] = True
+    experiment.write_artifacts(wrong_decision, output)
+    with pytest.raises(ValueError, match="recomputed decision"):
+        experiment.verify_artifacts(output)
+
+
+def test_verifier_rejects_row_relabel_duplicate_diagnostics_and_digest_tamper(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output = tmp_path / "radio-spectrum.json"
+
+    relabel = copy.deepcopy(focused_report)
+    relabel["training"][0]["phase"] = "held_out"
+    experiment.write_artifacts(focused_report, output)
+    _rewrite(output, relabel)
+    with pytest.raises(ValueError, match="benchmark row exact type/value"):
+        experiment.verify_artifacts(output)
+
+    duplicate = copy.deepcopy(focused_report)
+    duplicate["training"][1] = copy.deepcopy(duplicate["training"][0])
+    experiment.write_artifacts(focused_report, output)
+    _rewrite(output, duplicate)
+    with pytest.raises(ValueError, match="benchmark row exact type/value"):
+        experiment.verify_artifacts(output)
+
+    diagnostics = copy.deepcopy(focused_report)
+    diagnostics["training"][0]["query_diagnostics"]["candidate_median"] += 1.0
+    experiment.write_artifacts(focused_report, output)
+    _rewrite(output, diagnostics)
+    with pytest.raises(ValueError, match="query diagnostics exact/derived"):
+        experiment.verify_artifacts(output)
+
+    digest = copy.deepcopy(focused_report)
+    digest["training"][0]["final_state_sha256"] = "0" * 64
+    experiment.write_artifacts(focused_report, output)
+    _rewrite(output, digest)
+    with pytest.raises(ValueError, match="final state digest"):
+        experiment.verify_artifacts(output)
+
+
+def test_verifier_recomputes_provenance_and_markdown(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output = tmp_path / "radio-spectrum.json"
+    wrong_source = copy.deepcopy(focused_report)
+    wrong_source["provenance"]["sources"][0]["sha256"] = "0" * 64
+    experiment.write_artifacts(wrong_source, output)
+    with pytest.raises(ValueError, match="provenance"):
+        experiment.verify_artifacts(output)
+
+    experiment.write_artifacts(focused_report, output)
+    output.with_suffix(".md").write_text("unbound\n")
+    with pytest.raises(ValueError, match="Markdown mismatch"):
+        experiment.verify_artifacts(output)

--- a/tests/performance/experiments/test_rangeset_snapshot_scaling.py
+++ b/tests/performance/experiments/test_rangeset_snapshot_scaling.py
@@ -1,0 +1,325 @@
+"""Focused strict checks for the geometry snapshot scaling experiment."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.performance.experiments import rangeset_snapshot_scaling as experiment
+from treemendous import RangeSnapshot, Span, create_range_set
+
+
+def test_faithful_uncached_construction_matches_without_public_identity_reuse() -> None:
+    ranges = create_range_set((0, 30), backend="py_boundary", initially_available=False)
+    ranges.add(Span(2, 5))
+    ranges.add(Span(10, 14))
+    cached = ranges.snapshot()
+    first = experiment._uncached_snapshot(ranges)
+    second = experiment._uncached_snapshot(ranges)
+
+    assert type(cached) is RangeSnapshot
+    assert type(first) is RangeSnapshot
+    assert cached == first == second
+    assert cached is ranges.snapshot()
+    assert first is not cached and second is not cached and first is not second
+
+
+def _synthetic_row(kind: str, count: int, blocks: int) -> dict[str, Any]:
+    iterations = experiment.PILOT_MIN_ITERATIONS
+    raw_blocks: list[dict[str, Any]] = []
+    cached_totals: list[int] = []
+    uncached_totals: list[int] = []
+    for block_index in range(blocks):
+        cached_base = 20_000 if kind == "write_then_observe_restorative" else 1_000
+        cached_values = [cached_base + block_index, cached_base + block_index + 10]
+        uncached_values = [10_000 + block_index, 10_020 + block_index]
+        orderings = (
+            ["cached_first", "uncached_first"]
+            if block_index % 2 == 0
+            else ["uncached_first", "cached_first"]
+        )
+        positions = [
+            {
+                "ordering": ordering,
+                "cached_ns": cached_value,
+                "uncached_ns": uncached_value,
+            }
+            for ordering, cached_value, uncached_value in zip(
+                orderings, cached_values, uncached_values, strict=True
+            )
+        ]
+        cached_total = sum(cached_values)
+        uncached_total = sum(uncached_values)
+        raw_blocks.append(
+            {
+                "block_index": block_index,
+                "positions": positions,
+                "cached_ns_total": cached_total,
+                "uncached_ns_total": uncached_total,
+                "ratio": cached_total / uncached_total,
+            }
+        )
+        cached_totals.append(cached_total)
+        uncached_totals.append(uncached_total)
+    seed = experiment.BOOTSTRAP_SEED + count * (
+        1 if kind == "unchanged_read_burst" else 2
+    )
+    ratios, ratio = experiment._ratio_summary(cached_totals, uncached_totals, seed)
+    divisor = 2 * iterations
+    return {
+        "kind": kind,
+        "interval_count": count,
+        "operations_per_iteration": (
+            experiment.UNCHANGED_READS if kind == "unchanged_read_burst" else 4
+        ),
+        "iterations_per_position": iterations,
+        "pilot": {
+            "target_position_ns": experiment.PILOT_TARGET_NS,
+            "maximum_iterations": experiment.PILOT_MAX_ITERATIONS,
+            "order": "cached_then_uncached",
+            "measurements": [
+                {
+                    "iterations": iterations,
+                    "cached_ns": experiment.PILOT_TARGET_NS + 1,
+                    "uncached_ns": experiment.PILOT_TARGET_NS + 2,
+                }
+            ],
+            "selected_iterations": iterations,
+            "target_reached_by_both": True,
+            "excluded_from_blocks_and_gates": True,
+        },
+        "blocks": raw_blocks,
+        "block_ratios": ratios,
+        "cached_ns_per_iteration": experiment._summary(
+            [value / divisor for value in cached_totals], seed + 1
+        ),
+        "uncached_ns_per_iteration": experiment._summary(
+            [value / divisor for value in uncached_totals], seed + 2
+        ),
+        "ratio": ratio,
+        "validated_blocks": blocks,
+        "final_snapshot_sha256": experiment._expected_snapshot_digest(count),
+    }
+
+
+@pytest.fixture(scope="module")
+def focused_report() -> dict[str, Any]:
+    blocks = experiment.CONFIRMATION_BLOCKS
+    rows = [
+        _synthetic_row(kind, count, blocks)
+        for count in experiment.INTERVAL_COUNTS
+        for kind in ("unchanged_read_burst", "write_then_observe_restorative")
+    ]
+    return {
+        "schema": experiment.SCHEMA,
+        "blocks": blocks,
+        "methodology": experiment._methodology(),
+        "rows": rows,
+        "gate": experiment._gate(rows),
+        "provenance": experiment._provenance(),
+    }
+
+
+def test_focused_matrix_has_balanced_raw_blocks_and_exact_derivations(
+    focused_report: dict[str, Any],
+) -> None:
+    assert focused_report["gate"]["decision"] == "REJECTED"
+    assert focused_report["blocks"] == 40
+    assert focused_report["blocks"] >= experiment.MINIMUM_BLOCKS
+    for row in focused_report["rows"]:
+        assert row["validated_blocks"] == experiment.CONFIRMATION_BLOCKS
+        assert row["iterations_per_position"] >= 2
+        assert row["pilot"]["excluded_from_blocks_and_gates"] is True
+        assert len(row["blocks"]) == experiment.CONFIRMATION_BLOCKS
+        assert len(row["block_ratios"]) == experiment.CONFIRMATION_BLOCKS
+        for block in row["blocks"]:
+            assert {position["ordering"] for position in block["positions"]} == {
+                "cached_first",
+                "uncached_first",
+            }
+            assert block["cached_ns_total"] == sum(
+                position["cached_ns"] for position in block["positions"]
+            )
+            assert block["uncached_ns_total"] == sum(
+                position["uncached_ns"] for position in block["positions"]
+            )
+            assert block["ratio"] == (
+                block["cached_ns_total"] / block["uncached_ns_total"]
+            )
+
+
+def test_artifact_triplet_round_trips_through_strict_verifier(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output = tmp_path / "snapshot-scaling.json"
+    paths = experiment.write_artifacts(focused_report, output)
+    verified = experiment.verify_artifacts(output)
+    assert verified == focused_report
+    assert all(path.is_file() for path in paths)
+    digest = hashlib.sha256(output.read_bytes()).hexdigest()
+    assert digest in output.with_suffix(".md").read_text()
+
+
+def _rewrite(output: Path, text: str) -> None:
+    encoded = text.encode()
+    output.write_bytes(encoded)
+    digest = hashlib.sha256(encoded).hexdigest()
+    Path(f"{output}.sha256").write_text(f"{digest}  {output.name}\n")
+
+
+def test_verifier_rejects_duplicate_nonfinite_and_exact_type_tampering(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output = tmp_path / "snapshot-scaling.json"
+    experiment.write_artifacts(focused_report, output)
+    duplicate = output.read_text().replace(
+        f'  "schema": "{experiment.SCHEMA}"',
+        f'  "schema": "duplicate",\n  "schema": "{experiment.SCHEMA}"',
+        1,
+    )
+    _rewrite(output, duplicate)
+    with pytest.raises(ValueError, match="duplicate key"):
+        experiment.verify_artifacts(output)
+
+    nonfinite = copy.deepcopy(focused_report)
+    nonfinite["rows"][0]["blocks"][0]["ratio"] = float("nan")
+    _rewrite(output, json.dumps(nonfinite, indent=2, sort_keys=True) + "\n")
+    with pytest.raises(ValueError, match="non-finite"):
+        experiment.verify_artifacts(output)
+
+    wrong_type = copy.deepcopy(focused_report)
+    wrong_type["rows"][0]["blocks"][0]["positions"][0]["cached_ns"] = True
+    experiment.write_artifacts(wrong_type, output)
+    with pytest.raises(ValueError, match="balanced block ordering/duration"):
+        experiment.verify_artifacts(output)
+
+
+def test_verifier_rejects_block_order_iterations_totals_and_derivations(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output = tmp_path / "snapshot-scaling.json"
+
+    wrong_order = copy.deepcopy(focused_report)
+    wrong_order["rows"][0]["blocks"][0]["positions"][0]["ordering"] = "uncached_first"
+    experiment.write_artifacts(wrong_order, output)
+    with pytest.raises(ValueError, match="balanced block ordering"):
+        experiment.verify_artifacts(output)
+
+    wrong_iterations = copy.deepcopy(focused_report)
+    wrong_iterations["rows"][0]["iterations_per_position"] = 3
+    experiment.write_artifacts(wrong_iterations, output)
+    with pytest.raises(ValueError, match="pilot fixed methodology"):
+        experiment.verify_artifacts(output)
+
+    wrong_pilot_duration = copy.deepcopy(focused_report)
+    wrong_pilot_duration["rows"][0]["pilot"]["measurements"][0]["cached_ns"] = 0
+    experiment.write_artifacts(wrong_pilot_duration, output)
+    with pytest.raises(ValueError, match="pilot duration/iteration"):
+        experiment.verify_artifacts(output)
+
+    wrong_total = copy.deepcopy(focused_report)
+    wrong_total["rows"][0]["blocks"][0]["cached_ns_total"] += 1
+    experiment.write_artifacts(wrong_total, output)
+    with pytest.raises(ValueError, match="raw block total/ratio"):
+        experiment.verify_artifacts(output)
+
+    wrong_ratio = copy.deepcopy(focused_report)
+    wrong_ratio["rows"][0]["ratio"]["median_95_high"] += 0.01
+    experiment.write_artifacts(wrong_ratio, output)
+    with pytest.raises(ValueError, match="derived block ratio interval"):
+        experiment.verify_artifacts(output)
+
+
+def test_verifier_recomputes_gates_snapshot_and_markdown(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output = tmp_path / "snapshot-scaling.json"
+
+    wrong_gate = copy.deepcopy(focused_report)
+    wrong_gate["gate"]["decision"] = "ACCEPTED"
+    experiment.write_artifacts(wrong_gate, output)
+    with pytest.raises(ValueError, match="gate mismatch"):
+        experiment.verify_artifacts(output)
+
+    wrong_snapshot = copy.deepcopy(focused_report)
+    wrong_snapshot["rows"][0]["final_snapshot_sha256"] = "0" * 64
+    experiment.write_artifacts(wrong_snapshot, output)
+    with pytest.raises(ValueError, match="snapshot digest semantic mismatch"):
+        experiment.verify_artifacts(output)
+
+    experiment.write_artifacts(focused_report, output)
+    output.with_suffix(".md").write_text("unbound report\n")
+    with pytest.raises(ValueError, match="Markdown mismatch"):
+        experiment.verify_artifacts(output)
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        ("runtime", "python_version"),
+        ("runtime", "python_implementation"),
+        ("runtime", "python_compiler"),
+        ("runtime", "platform"),
+        ("runtime", "machine"),
+        ("runtime", "architecture"),
+        ("build", "command"),
+        ("build", "cxx"),
+        ("build", "cxx_version"),
+        ("build", "cc"),
+        ("build", "cflags"),
+        ("build", "flags", "TREE_MENDOUS_WITH_ICL"),
+        ("backend", "id"),
+        ("backend", "module"),
+        ("backend", "type"),
+        ("backend", "path"),
+        ("backend", "sha256"),
+    ),
+)
+def test_verifier_rejects_each_runtime_build_and_backend_provenance_category(
+    tmp_path: Path, focused_report: dict[str, Any], path: tuple[str, ...]
+) -> None:
+    output = tmp_path / "snapshot-scaling.json"
+    tampered = copy.deepcopy(focused_report)
+    target = tampered["provenance"]
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = True
+    experiment.write_artifacts(tampered, output)
+
+    with pytest.raises(ValueError, match="runtime|build|active backend"):
+        experiment.verify_artifacts(output)
+
+
+def test_verifier_rejects_exact_methodology_and_provenance_hash_tamper(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output = tmp_path / "snapshot-scaling.json"
+
+    wrong_method = copy.deepcopy(focused_report)
+    wrong_method["methodology"]["balanced_block_method"] = "tampered"
+    experiment.write_artifacts(wrong_method, output)
+    with pytest.raises(ValueError, match="fixed matrix/methodology"):
+        experiment.verify_artifacts(output)
+
+    wrong_block_count = copy.deepcopy(focused_report)
+    wrong_block_count["blocks"] = experiment.MINIMUM_BLOCKS
+    experiment.write_artifacts(wrong_block_count, output)
+    with pytest.raises(ValueError, match="fixed block count"):
+        experiment.verify_artifacts(output)
+
+    wrong_source_state = copy.deepcopy(focused_report)
+    wrong_source_state["provenance"]["git"]["source_state_sha256"] = "0" * 64
+    experiment.write_artifacts(wrong_source_state, output)
+    with pytest.raises(ValueError, match="git/source-state provenance"):
+        experiment.verify_artifacts(output)
+
+    wrong_source_file = copy.deepcopy(focused_report)
+    wrong_source_file["provenance"]["sources"][0]["sha256"] = "0" * 64
+    experiment.write_artifacts(wrong_source_file, output)
+    with pytest.raises(ValueError, match="source provenance path/hash"):
+        experiment.verify_artifacts(output)

--- a/tests/performance/experiments/test_rangeset_transaction.py
+++ b/tests/performance/experiments/test_rangeset_transaction.py
@@ -1,0 +1,588 @@
+"""Focused contracts for the private payload-aware transaction experiment."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.performance.experiments import rangeset_transaction as experiment
+from treemendous import (
+    JoinPayloadPolicy,
+    OrderedPayloadPolicy,
+    Span,
+    UniformPayloadPolicy,
+    create_range_set,
+)
+from treemendous.backends.adapters import BackendAdapter
+from treemendous.backends.registry import BackendRegistry
+from treemendous.backends.types import Available, Capability, Maturity
+from treemendous.basic.boundary import IntervalManager
+from treemendous.domain import MutationResult
+from treemendous.rangeset import RangeSet
+
+
+def _raw(ranges: RangeSet) -> tuple[tuple[int, int], ...]:
+    return tuple((item.start, item.end) for item in ranges._adapter.intervals())
+
+
+def _assert_unchanged(
+    ranges: RangeSet, before_snapshot: Any, before_raw: tuple[tuple[int, int], ...]
+) -> None:
+    assert ranges.snapshot() == before_snapshot
+    assert _raw(ranges) == before_raw
+
+
+def _policy(kind: str) -> Any:
+    if kind == "uniform":
+        return UniformPayloadPolicy()
+    if kind == "join":
+        return JoinPayloadPolicy(lambda left, right: left | right, frozenset())
+    if kind == "ordered":
+        return OrderedPayloadPolicy(
+            lambda left, right: left + right,
+            (),
+            event_key_fn=lambda value: value,
+        )
+    return None
+
+
+def _payload(kind: str, label: int) -> Any:
+    if kind == "uniform":
+        return label
+    if kind == "join":
+        return frozenset({label})
+    if kind == "ordered":
+        return (label,)
+    return experiment._MISSING
+
+
+def _source(kind: str = "none", backend: str = "py_boundary") -> RangeSet:
+    ranges = create_range_set(
+        (0, 40),
+        backend=backend,
+        initially_available=False,
+        payload_policy=_policy(kind),
+    )
+    payload = _payload(kind, 1)
+    if payload is experiment._MISSING:
+        ranges.add(Span(4, 12))
+        ranges.add(Span(20, 28))
+    else:
+        ranges.add(Span(4, 12), payload)
+        ranges.add(Span(20, 28), payload)
+    return ranges
+
+
+def _trace(kind: str) -> tuple[experiment._TransactionOperation, ...]:
+    add_payload = _payload(kind, 1)
+    return (
+        experiment._TransactionOperation("discard", Span(6, 10)),
+        experiment._TransactionOperation("add", Span(8, 16), add_payload),
+        experiment._TransactionOperation("strict-discard", Span(0, 2)),
+        experiment._TransactionOperation("discard", Span(22, 25)),
+    )
+
+
+@pytest.mark.parametrize("kind", ("none", "uniform", "join", "ordered"))
+def test_transaction_matches_ordered_scalar_results_and_snapshot(kind: str) -> None:
+    transaction_ranges = _source(kind)
+    scalar_ranges = _source(kind)
+    operations = _trace(kind)
+
+    expected = experiment._scalar(scalar_ranges, operations)
+    actual = experiment._rangeset_transaction(transaction_ranges, operations)
+
+    assert actual == expected
+    assert all(type(row) is MutationResult for row in actual)
+    assert transaction_ranges.snapshot() == scalar_ranges.snapshot()
+    assert actual[2] == MutationResult((), 0, False)
+
+
+def test_empty_transaction_and_cancellation_non_restorative_traces() -> None:
+    empty = _source()
+    before = empty.snapshot()
+    assert experiment._rangeset_transaction(empty, ()) == ()
+    assert empty.snapshot() == before
+
+    restorative = _source()
+    scalar = _source()
+    restore_trace = (
+        experiment._TransactionOperation("discard", Span(4, 8)),
+        experiment._TransactionOperation("add", Span(4, 8)),
+    )
+    assert experiment._rangeset_transaction(
+        restorative, restore_trace
+    ) == experiment._scalar(scalar, restore_trace)
+    assert restorative.snapshot() == scalar.snapshot()
+
+    application = _source()
+    scalar_application = _source()
+    non_restore = (
+        experiment._TransactionOperation("add", Span(12, 14)),
+        experiment._TransactionOperation("discard", Span(21, 24)),
+        experiment._TransactionOperation("add", Span(30, 32)),
+    )
+    assert experiment._rangeset_transaction(
+        application, non_restore
+    ) == experiment._scalar(scalar_application, non_restore)
+    assert application.snapshot() == scalar_application.snapshot()
+
+
+def test_mutable_payloads_are_isolated_and_custom_cloner_is_used() -> None:
+    clone_calls: list[list[str]] = []
+
+    def cloner(value: list[str] | None) -> list[str] | None:
+        clone_calls.append([] if value is None else list(value))
+        return copy.deepcopy(value)
+
+    ranges = create_range_set(
+        (0, 20),
+        backend="py_boundary",
+        initially_available=False,
+        payload_policy=UniformPayloadPolicy[list[str]](),
+        payload_cloner=cloner,
+    )
+    initial = ["initial"]
+    ranges.add(Span(2, 6), initial)
+    incoming = ["next"]
+    operations = (experiment._TransactionOperation("add", Span(8, 10), incoming),)
+    experiment._rangeset_transaction(ranges, operations)
+    incoming.append("mutated")
+    observed = ranges.intervals()
+    assert observed[1].data == ["next"]
+    observed[1].data.append("escaped")
+    assert ranges.intervals()[1].data == ["next"]
+    assert len(clone_calls) > 4
+
+
+def test_materialization_domain_and_result_failures_do_not_publish() -> None:
+    ranges = _source()
+    before = ranges.snapshot()
+    raw = _raw(ranges)
+
+    def broken_iterable() -> Iterator[Any]:
+        yield ("discard", (4, 5))
+        raise LookupError("iterator failed")
+
+    with pytest.raises(LookupError, match="iterator failed"):
+        experiment._rangeset_transaction(ranges, broken_iterable())
+    _assert_unchanged(ranges, before, raw)
+
+    with pytest.raises(ValueError, match="managed domain"):
+        experiment._rangeset_transaction(ranges, (("add", (50, 51)),))
+    _assert_unchanged(ranges, before, raw)
+
+    def result_failure(*_args: Any) -> Any:
+        raise RuntimeError("result failed")
+
+    with pytest.raises(RuntimeError, match="result failed"):
+        experiment._rangeset_transaction(
+            ranges,
+            (("discard", (4, 5)),),
+            _result_factory=result_failure,
+        )
+    _assert_unchanged(ranges, before, raw)
+
+    with pytest.raises(TypeError, match="exact MutationResult"):
+        experiment._rangeset_transaction(
+            ranges,
+            (("discard", (4, 5)),),
+            _result_factory=lambda *_args: object(),
+        )
+    _assert_unchanged(ranges, before, raw)
+
+
+@pytest.mark.parametrize("failure_at", (1, 2, 3, 4, 5))
+def test_injected_backend_failure_after_each_staged_prefix(
+    monkeypatch: pytest.MonkeyPatch, failure_at: int
+) -> None:
+    ranges = _source("uniform")
+    before = ranges.snapshot()
+    raw = _raw(ranges)
+    original_implementation = ranges._adapter.implementation
+    calls = 0
+    original_release = IntervalManager.release_interval
+    original_reserve = IntervalManager.reserve_interval
+
+    def checkpoint(instance: IntervalManager) -> None:
+        nonlocal calls
+        if instance is original_implementation:
+            return
+        calls += 1
+        if calls == failure_at:
+            raise RuntimeError(f"backend prefix {failure_at}")
+
+    def release(instance: IntervalManager, start: int, end: int) -> None:
+        checkpoint(instance)
+        original_release(instance, start, end)
+
+    def reserve(instance: IntervalManager, start: int, end: int) -> None:
+        checkpoint(instance)
+        original_reserve(instance, start, end)
+
+    monkeypatch.setattr(IntervalManager, "release_interval", release)
+    monkeypatch.setattr(IntervalManager, "reserve_interval", reserve)
+    operations = (
+        experiment._TransactionOperation("discard", Span(4, 6)),
+        experiment._TransactionOperation("add", Span(12, 14), 1),
+        experiment._TransactionOperation("discard", Span(20, 22)),
+    )
+    with pytest.raises(RuntimeError, match="backend prefix"):
+        experiment._rangeset_transaction(ranges, operations)
+    _assert_unchanged(ranges, before, raw)
+
+
+def test_cloner_failure_does_not_publish() -> None:
+    armed = False
+
+    def cloner(value: Any) -> Any:
+        if armed:
+            raise RuntimeError("clone failed")
+        return copy.deepcopy(value)
+
+    ranges = create_range_set(
+        (0, 10),
+        backend="py_boundary",
+        initially_available=False,
+        payload_policy=UniformPayloadPolicy(),
+        payload_cloner=cloner,
+    )
+    ranges.add(Span(1, 3), "x")
+    before = ranges.snapshot()
+    raw = _raw(ranges)
+    armed = True
+    with pytest.raises(RuntimeError, match="clone failed"):
+        experiment._rangeset_transaction(ranges, ())
+    armed = False
+    _assert_unchanged(ranges, before, raw)
+
+
+@pytest.mark.parametrize("callback", ("can_merge", "combine", "restrict", "cloner"))
+def test_payload_callbacks_cannot_reenter_source(callback: str) -> None:
+    armed = False
+    source: RangeSet
+
+    class Policy:
+        def attempt(self, name: str) -> None:
+            if armed and callback == name:
+                source.add(Span(14, 15), "reentry")
+
+        def can_merge(self, left: str, right: str) -> bool:
+            self.attempt("can_merge")
+            return left == right
+
+        def combine(self, left: str, right: str) -> str:
+            self.attempt("combine")
+            return left
+
+        def restrict(self, data: str, source_span: Span, target: Span) -> str:
+            self.attempt("restrict")
+            return data
+
+    policy = Policy()
+
+    def cloner(value: Any) -> Any:
+        if armed and callback == "cloner":
+            source.add(Span(14, 15), "reentry")
+        return copy.deepcopy(value)
+
+    source = create_range_set(
+        (0, 20),
+        backend="py_boundary",
+        initially_available=False,
+        payload_policy=policy,
+        payload_cloner=cloner,
+    )
+    source.add(Span(2, 6), "x")
+    before = source.snapshot()
+    raw = _raw(source)
+    armed = True
+    operation = experiment._TransactionOperation("add", Span(4, 8), "x")
+    with pytest.raises(RuntimeError, match="payload processing"):
+        experiment._rangeset_transaction(source, (operation,))
+    armed = False
+    _assert_unchanged(source, before, raw)
+
+
+def test_operation_iterator_cannot_reenter_source() -> None:
+    source = _source()
+    before = source.snapshot()
+    raw = _raw(source)
+
+    def operations() -> Iterator[Any]:
+        source.discard(Span(4, 5))
+        yield ("add", (12, 14))
+
+    with pytest.raises(RuntimeError, match="reentrant mutation"):
+        experiment._rangeset_transaction(source, operations())
+    _assert_unchanged(source, before, raw)
+
+
+def test_custom_adapter_is_rejected_before_operation_iteration() -> None:
+    class DirectManager(IntervalManager):
+        pass
+
+    ranges = RangeSet(BackendAdapter(DirectManager()), domain=(0, 10))
+    iterated = False
+
+    def operations() -> Iterator[Any]:
+        nonlocal iterated
+        iterated = True
+        yield ("discard", (0, 1))
+
+    with pytest.raises(experiment._UnsupportedAdapterError, match="custom adapters"):
+        experiment._rangeset_transaction(ranges, operations())
+    assert not iterated
+
+
+def test_all_discovered_stable_deterministic_core_factories_match_scalar() -> None:
+    registry = BackendRegistry.discover()
+    exercised: list[str] = []
+    for spec in registry.specs:
+        state = registry.states[spec.id]
+        if not (
+            isinstance(state, Available)
+            and spec.maturity is Maturity.STABLE
+            and spec.deterministic
+            and Capability.CORE in spec.capabilities
+        ):
+            continue
+        transaction_ranges = _source(backend=spec.id)
+        scalar_ranges = _source(backend=spec.id)
+        operations = _trace("none")
+        actual = experiment._rangeset_transaction(transaction_ranges, operations)
+        expected = experiment._scalar(scalar_ranges, operations)
+        assert actual == expected, spec.id
+        assert transaction_ranges.snapshot() == scalar_ranges.snapshot(), spec.id
+        exercised.append(spec.id)
+    assert exercised
+
+
+@pytest.fixture(scope="module")
+def focused_report() -> dict[str, Any]:
+    return experiment.run_matrix(
+        samples=15,
+        interval_counts=(64,),
+        batch_sizes=(0, 1, 4),
+    )
+
+
+def test_bounded_report_writes_and_verifies_strict_triplet(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output = tmp_path / "transaction.json"
+    paths = experiment.write_artifacts(focused_report, output)
+    verified = experiment.verify_artifacts(output)
+    assert verified["gate"]["decision"] == "REJECTED"
+    assert all(path.is_file() for path in paths)
+
+
+def _rewrite(output: Path, text: str) -> None:
+    encoded = text.encode()
+    output.write_bytes(encoded)
+    digest = hashlib.sha256(encoded).hexdigest()
+    Path(f"{output}.sha256").write_text(f"{digest}  {output.name}\n")
+
+
+def test_verifier_rejects_duplicate_nonfinite_and_exact_type_tamper(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output = tmp_path / "transaction.json"
+    experiment.write_artifacts(focused_report, output)
+    duplicate = output.read_text().replace(
+        f'  "schema": "{experiment.SCHEMA}"',
+        f'  "schema": "duplicate",\n  "schema": "{experiment.SCHEMA}"',
+        1,
+    )
+    _rewrite(output, duplicate)
+    with pytest.raises(ValueError, match="duplicate key"):
+        experiment.verify_artifacts(output)
+
+    tampered = copy.deepcopy(focused_report)
+    tampered["rows"][0]["paired_ratios"][0] = float("nan")
+    text = json.dumps(tampered, indent=2, sort_keys=True) + "\n"
+    _rewrite(output, text)
+    with pytest.raises(ValueError, match="non-finite"):
+        experiment.verify_artifacts(output)
+
+    tampered = copy.deepcopy(focused_report)
+    tampered["rows"][0]["scalar_ns_samples"][0] = True
+    experiment.write_artifacts(tampered, output)
+    with pytest.raises(ValueError, match="raw paired ratios|exact type"):
+        experiment.verify_artifacts(output)
+
+
+@pytest.mark.parametrize(
+    ("expected_batch", "replacement"),
+    ((0, False), (1, True)),
+)
+def test_verifier_rejects_false_zero_and_true_one_row_identity_tamper(
+    tmp_path: Path,
+    focused_report: dict[str, Any],
+    expected_batch: int,
+    replacement: bool,
+) -> None:
+    output = tmp_path / "transaction.json"
+    tampered = copy.deepcopy(focused_report)
+    row = next(row for row in tampered["rows"] if row["batch_size"] == expected_batch)
+    row["batch_size"] = replacement
+    experiment.write_artifacts(tampered, output)
+
+    with pytest.raises(ValueError, match="row identity exact type"):
+        experiment.verify_artifacts(output)
+
+
+@pytest.mark.parametrize(
+    ("index", "replacement"),
+    ((0, False), (1, True)),
+)
+def test_verifier_rejects_false_zero_and_true_one_matrix_dimension_tamper(
+    tmp_path: Path,
+    focused_report: dict[str, Any],
+    index: int,
+    replacement: bool,
+) -> None:
+    output = tmp_path / "transaction.json"
+    tampered = copy.deepcopy(focused_report)
+    tampered["matrix"]["batch_sizes"][index] = replacement
+    experiment.write_artifacts(tampered, output)
+
+    with pytest.raises(ValueError, match="fixed matrix membership"):
+        experiment.verify_artifacts(output)
+
+
+@pytest.mark.parametrize(
+    ("field", "replacement"),
+    (
+        ("interval_count", False),
+        ("backend", 0),
+        ("payload", 0),
+        ("trace", 0),
+    ),
+)
+def test_verifier_exact_type_checks_every_row_identity_field(
+    tmp_path: Path,
+    focused_report: dict[str, Any],
+    field: str,
+    replacement: bool | int,
+) -> None:
+    output = tmp_path / "transaction.json"
+    tampered = copy.deepcopy(focused_report)
+    tampered["rows"][0][field] = replacement
+    experiment.write_artifacts(tampered, output)
+
+    with pytest.raises(ValueError, match="row identity exact type"):
+        experiment.verify_artifacts(output)
+
+
+@pytest.mark.parametrize(
+    "path",
+    (
+        ("runtime", "python_version"),
+        ("runtime", "python_implementation"),
+        ("runtime", "python_compiler"),
+        ("runtime", "platform"),
+        ("runtime", "machine"),
+        ("runtime", "architecture"),
+        ("build", "command"),
+        ("build", "cxx"),
+        ("build", "cxx_version"),
+        ("build", "cc"),
+        ("build", "cflags"),
+        ("build", "flags", "TREE_MENDOUS_WITH_ICL"),
+        ("backend", "id"),
+        ("backend", "module"),
+        ("backend", "type"),
+        ("backend", "path"),
+        ("backend", "sha256"),
+    ),
+)
+def test_verifier_rejects_each_runtime_build_and_backend_provenance_category(
+    tmp_path: Path, focused_report: dict[str, Any], path: tuple[str, ...]
+) -> None:
+    output = tmp_path / "transaction.json"
+    tampered = copy.deepcopy(focused_report)
+    target = tampered["provenance"]
+    for key in path[:-1]:
+        target = target[key]
+    target[path[-1]] = True
+    experiment.write_artifacts(tampered, output)
+
+    with pytest.raises(ValueError, match="runtime|build|active backend"):
+        experiment.verify_artifacts(output)
+
+
+def test_verifier_rejects_matrix_row_digest_method_and_provenance_tamper(
+    tmp_path: Path, focused_report: dict[str, Any]
+) -> None:
+    output = tmp_path / "transaction.json"
+
+    matrix = copy.deepcopy(focused_report)
+    matrix["matrix"]["batch_sizes"] = [0, 1]
+    experiment.write_artifacts(matrix, output)
+    with pytest.raises(ValueError, match="fixed matrix membership"):
+        experiment.verify_artifacts(output)
+
+    reordered = copy.deepcopy(focused_report)
+    reordered["rows"][0], reordered["rows"][1] = (
+        reordered["rows"][1],
+        reordered["rows"][0],
+    )
+    reordered["gate"] = experiment._gate(reordered["rows"])
+    experiment.write_artifacts(reordered, output)
+    with pytest.raises(ValueError, match="membership/order"):
+        experiment.verify_artifacts(output)
+
+    extra = copy.deepcopy(focused_report)
+    extra["rows"][0]["extra"] = True
+    experiment.write_artifacts(extra, output)
+    with pytest.raises(ValueError, match="row keys/type"):
+        experiment.verify_artifacts(output)
+
+    report_extra = copy.deepcopy(focused_report)
+    report_extra["extra"] = True
+    experiment.write_artifacts(report_extra, output)
+    with pytest.raises(ValueError, match="report keys/type"):
+        experiment.verify_artifacts(output)
+
+    gate = copy.deepcopy(focused_report)
+    gate["gate"]["decision"] = "ACCEPTED"
+    experiment.write_artifacts(gate, output)
+    with pytest.raises(ValueError, match="gate mismatch"):
+        experiment.verify_artifacts(output)
+
+    result_digest = copy.deepcopy(focused_report)
+    result_digest["rows"][0]["result_sha256"] = "0" * 64
+    experiment.write_artifacts(result_digest, output)
+    with pytest.raises(ValueError, match="result digest"):
+        experiment.verify_artifacts(output)
+
+    final_digest = copy.deepcopy(focused_report)
+    final_digest["rows"][0]["final_state_sha256"] = "0" * 64
+    experiment.write_artifacts(final_digest, output)
+    with pytest.raises(ValueError, match="final-state digest"):
+        experiment.verify_artifacts(output)
+
+    method = copy.deepcopy(focused_report)
+    method["matrix"]["timed_boundary"] = "tampered"
+    experiment.write_artifacts(method, output)
+    with pytest.raises(ValueError, match="methodology"):
+        experiment.verify_artifacts(output)
+
+    source = copy.deepcopy(focused_report)
+    source["provenance"]["sources"][0]["sha256"] = "0" * 64
+    experiment.write_artifacts(source, output)
+    with pytest.raises(ValueError, match="source provenance"):
+        experiment.verify_artifacts(output)
+
+    binary = copy.deepcopy(focused_report)
+    binary["provenance"]["backend"]["sha256"] = "0" * 64
+    experiment.write_artifacts(binary, output)
+    with pytest.raises(ValueError, match="active backend"):
+        experiment.verify_artifacts(output)

--- a/tests/unit/test_exact_batch.py
+++ b/tests/unit/test_exact_batch.py
@@ -350,6 +350,20 @@ def test_native_allocation_failpoints_preserve_exact_pre_state(failpoint: str) -
     assert manager.snapshot() == before
 
 
+def test_rejected_segmented_storage_hooks_are_not_shipped() -> None:
+    manager = ExactBatchRangeSet((0, 64), initially_available=True)
+    assert not hasattr(manager._manager, "_storage_counters")
+    for failpoint in (
+        "directory_clone",
+        "block_rebuild",
+        "block_split",
+        "directory_replacement",
+        "root_creation",
+    ):
+        with pytest.raises(ValueError, match="unknown exact-batch failpoint"):
+            manager._manager._set_failpoint(failpoint)
+
+
 def test_ergonomic_materialization_failure_preserves_exact_pre_state() -> None:
     manager = ExactBatchRangeSet((0, 8), initially_available=False)
     before = manager.snapshot()

--- a/tests/unit/test_rangeset_snapshot_cache.py
+++ b/tests/unit/test_rangeset_snapshot_cache.py
@@ -1,0 +1,282 @@
+"""Exact contracts for the geometry-only ``RangeSet`` snapshot cache."""
+
+from __future__ import annotations
+
+import copy
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
+from typing import Any
+
+import pytest
+
+from treemendous import (
+    IntervalResult,
+    JoinPayloadPolicy,
+    OrderedPayloadPolicy,
+    RangeSnapshot,
+    Span,
+    UniformPayloadPolicy,
+    create_range_set,
+)
+from treemendous.backends import CATALOG, Available, Maturity, probe_backend
+from treemendous.backends.adapters import BackendAdapter
+from treemendous.basic.boundary import IntervalManager
+from treemendous.rangeset import RangeSet
+
+
+class _NonAuthoritativeManager:
+    def __init__(self) -> None:
+        self._manager = IntervalManager()
+
+    def release_interval(self, start: int, end: int) -> None:
+        self._manager.release_interval(start, end)
+
+    def reserve_interval(self, start: int, end: int) -> None:
+        self._manager.reserve_interval(start, end)
+
+    def get_intervals(self) -> list[IntervalResult]:
+        return self._manager.get_intervals()
+
+
+def test_geometry_snapshot_is_exact_complete_and_reused_until_change() -> None:
+    ranges = create_range_set(
+        ((0, 20), (30, 40)),
+        backend="py_boundary",
+        initially_available=False,
+    )
+    ranges.add(Span(10, 15))
+    ranges.add(Span(2, 6))
+
+    first = ranges.snapshot()
+    second = ranges.snapshot()
+    assert type(first) is RangeSnapshot
+    assert first is second
+    assert ranges._snapshot_cache is first
+    assert not hasattr(ranges, "_snapshot_version")
+    assert first == RangeSnapshot(
+        (
+            IntervalResult(2, 6),
+            IntervalResult(10, 15),
+        ),
+        9,
+        ranges.domain,
+    )
+    assert first.intervals == ranges.intervals()
+    assert first.total_free == sum(item.end - item.start for item in first.intervals)
+    assert first.domain is ranges.domain
+
+    changed = ranges.discard(Span(3, 5), require_covered=True)
+    assert changed.changed == (Span(3, 5),)
+    third = ranges.snapshot()
+    assert third is ranges.snapshot()
+    assert third is not first
+    assert third.intervals == (
+        IntervalResult(2, 3),
+        IntervalResult(5, 6),
+        IntervalResult(10, 15),
+    )
+
+    # Previously published snapshots remain immutable point-in-time values.
+    assert first.intervals == (IntervalResult(2, 6), IntervalResult(10, 15))
+    assert first.total_free == 9
+
+
+def test_non_authoritative_geometry_path_reuses_and_invalidates_exactly() -> None:
+    ranges = RangeSet(
+        BackendAdapter(_NonAuthoritativeManager()),
+        domain=(0, 20),
+        initially_available=False,
+    )
+    ranges.add(Span(2, 8))
+    cached = ranges.snapshot()
+    assert cached is ranges.snapshot()
+    assert not ranges.add(Span(3, 5)).changed
+    assert cached is ranges.snapshot()
+
+    ranges.discard(Span(4, 6), require_covered=True)
+    changed = ranges.snapshot()
+    assert changed is ranges.snapshot()
+    assert changed is not cached
+    assert changed.intervals == (IntervalResult(2, 4), IntervalResult(6, 8))
+    assert cached.intervals == (IntervalResult(2, 8),)
+
+
+def test_noop_rejected_discard_and_failed_allocate_retain_cached_snapshot() -> None:
+    ranges = create_range_set((0, 20), backend="py_boundary", initially_available=False)
+    ranges.add(Span(4, 8))
+    cached = ranges.snapshot()
+
+    assert not ranges.add(Span(5, 7)).changed
+    assert ranges.snapshot() is cached
+    assert not ranges.discard(Span(10, 12)).changed
+    assert ranges.snapshot() is cached
+    rejected = ranges.discard(Span(2, 6), require_covered=True)
+    assert rejected.changed == () and not rejected.fully_covered
+    assert ranges.snapshot() is cached
+    assert ranges.allocate(10, not_before=0) is None
+    assert ranges.snapshot() is cached
+
+    allocated = ranges.allocate(2, not_before=4)
+    assert allocated == IntervalResult(4, 6)
+    assert ranges.snapshot() is not cached
+
+
+@pytest.mark.parametrize("domain", (None, (0, 20), ((0, 5), (10, 20))))
+@pytest.mark.parametrize("initially_available", (False, True))
+def test_domain_and_initial_availability_variants_cache_exact_snapshots(
+    domain: Any, initially_available: bool
+) -> None:
+    ranges = create_range_set(
+        domain,
+        backend="py_boundary",
+        initially_available=initially_available,
+    )
+    first = ranges.snapshot()
+    assert type(first) is RangeSnapshot
+    assert first is ranges.snapshot()
+    assert first.domain == ranges.domain
+    assert first.intervals == ranges.intervals()
+    assert first.total_free == sum(item.end - item.start for item in first.intervals)
+
+
+class _MutablePolicy:
+    def can_merge(self, left: list[str], right: list[str]) -> bool:
+        return left == right
+
+    def combine(self, left: list[str], right: list[str]) -> list[str]:
+        return left + right
+
+    def restrict(self, data: list[str], source: Span, target: Span) -> list[str]:
+        assert source.contains(target)
+        return data
+
+
+@pytest.mark.parametrize(
+    ("policy", "payload"),
+    (
+        (UniformPayloadPolicy[list[str]](), ["uniform"]),
+        (
+            JoinPayloadPolicy[list[str]](
+                lambda left, right: left + right,
+                [],
+            ),
+            ["join"],
+        ),
+        (
+            OrderedPayloadPolicy[list[str]](
+                lambda left, right: left + right,
+                [],
+                event_key_fn=lambda value: tuple(value),
+            ),
+            ["ordered"],
+        ),
+        (_MutablePolicy(), ["custom"]),
+    ),
+    ids=("uniform", "join", "ordered", "custom"),
+)
+def test_payload_snapshots_remain_distinct_and_deeply_detached(
+    policy: Any, payload: list[str]
+) -> None:
+    ranges = create_range_set(
+        (0, 10),
+        backend="py_boundary",
+        initially_available=False,
+        payload_policy=policy,
+        payload_cloner=copy.deepcopy,
+    )
+    ranges.add(Span(2, 6), payload)
+    first = ranges.snapshot()
+    second = ranges.snapshot()
+    assert type(first) is RangeSnapshot
+    assert type(second) is RangeSnapshot
+    assert first == second
+    assert first is not second
+    assert first.intervals is not second.intervals
+    assert first.intervals[0] is not second.intervals[0]
+    assert first.intervals[0].data is not second.intervals[0].data
+
+    payload.append("caller mutation")
+    first.intervals[0].data.append("snapshot mutation")
+    assert ranges.snapshot().intervals[0].data not in (
+        payload,
+        first.intervals[0].data,
+    )
+
+
+def test_concurrent_snapshot_and_mutation_publications_are_consistent() -> None:
+    ranges = create_range_set(
+        (0, 200), backend="py_boundary", initially_available=False
+    )
+    for index in range(50):
+        ranges.add(Span(index * 4, index * 4 + 2))
+    start = Barrier(5)
+
+    def reader() -> tuple[RangeSnapshot, ...]:
+        start.wait()
+        observed = []
+        for _ in range(250):
+            snapshot = ranges.snapshot()
+            assert type(snapshot) is RangeSnapshot
+            assert snapshot.total_free == sum(
+                item.end - item.start for item in snapshot.intervals
+            )
+            assert all(
+                left.end < right.start
+                for left, right in zip(
+                    snapshot.intervals, snapshot.intervals[1:], strict=False
+                )
+            )
+            observed.append(snapshot)
+        return tuple(observed)
+
+    def writer() -> None:
+        start.wait()
+        target = Span(0, 2)
+        for _ in range(125):
+            assert ranges.discard(target, require_covered=True).changed
+            assert ranges.add(target).changed
+
+    with ThreadPoolExecutor(max_workers=5) as pool:
+        readers = [pool.submit(reader) for _ in range(4)]
+        mutation = pool.submit(writer)
+        histories = [future.result(timeout=10) for future in readers]
+        mutation.result(timeout=10)
+
+    assert all(history for history in histories)
+    assert ranges.snapshot().total_free == 100
+
+
+@pytest.mark.parametrize(
+    "spec",
+    tuple(spec for spec in CATALOG if spec.maturity is Maturity.STABLE),
+    ids=lambda spec: spec.id,
+)
+def test_cache_semantics_hold_for_every_available_stable_backend(spec: Any) -> None:
+    state = probe_backend(spec)
+    if not isinstance(state, Available):
+        pytest.fail(f"stable backend {spec.id} unavailable: {state}")
+    ranges = RangeSet(
+        BackendAdapter(spec.loader()(**dict(spec.constructor_args))),
+        domain=(0, 30),
+        initially_available=False,
+    )
+    ranges.add(Span(2, 5))
+    ranges.add(Span(10, 15))
+    cached = ranges.snapshot()
+    assert type(cached) is RangeSnapshot
+    assert ranges.snapshot() is cached
+    assert not ranges.add(Span(3, 4)).changed
+    assert ranges.snapshot() is cached
+    ranges.discard(Span(11, 13), require_covered=True)
+    changed = ranges.snapshot()
+    assert changed is ranges.snapshot()
+    assert changed is not cached
+    assert changed == RangeSnapshot(
+        (
+            IntervalResult(2, 5),
+            IntervalResult(10, 11),
+            IntervalResult(13, 15),
+        ),
+        6,
+        ranges.domain,
+    )

--- a/treemendous/applications/_shared/leasing.py
+++ b/treemendous/applications/_shared/leasing.py
@@ -229,6 +229,9 @@ class LeasePool:
         self._next_fencing_token = 1
         self._last_observed_at = observed_at
         self._free = self._build_free(self._leases)
+        self._lease_projection_cache: tuple[Lease, ...] | None = None
+        self._available_projection_cache: tuple[Span, ...] | None = None
+        self._state_counts_cache: tuple[int, int, int] | None = None
         self._lock = RLock()
 
     @staticmethod
@@ -259,6 +262,7 @@ class LeasePool:
         )
 
     def _build_free(self, leases: dict[int, Lease]) -> RangeSet:
+        """Reconstruct free state when initializing or validating a restore."""
         free = self._new_range_set()
         active = sorted(
             (lease for lease in leases.values() if lease.state is LeaseState.ACTIVE),
@@ -293,9 +297,56 @@ class LeasePool:
     def _commit(
         self, leases: dict[int, Lease], free: RangeSet, observed_at: int
     ) -> None:
+        leases_changed = leases is not self._leases
+        free_changed = free is not self._free
         self._leases = leases
         self._free = free
         self._last_observed_at = observed_at
+        if leases_changed:
+            self._lease_projection_cache = None
+            self._state_counts_cache = None
+        if free_changed:
+            self._available_projection_cache = None
+
+    def _lease_projection(self, leases: dict[int, Lease]) -> tuple[Lease, ...]:
+        if leases is self._leases and self._lease_projection_cache is not None:
+            return self._lease_projection_cache
+        return tuple(sorted(leases.values(), key=lambda lease: lease.token))
+
+    def _available_projection(self, free: RangeSet) -> tuple[Span, ...]:
+        if free is self._free and self._available_projection_cache is not None:
+            return self._available_projection_cache
+        return tuple(interval.span for interval in free.intervals())
+
+    def _state_counts(self, leases: dict[int, Lease]) -> tuple[int, int, int]:
+        if leases is self._leases and self._state_counts_cache is not None:
+            return self._state_counts_cache
+        active = expired = released = 0
+        for lease in leases.values():
+            if lease.state is LeaseState.ACTIVE:
+                active += 1
+            elif lease.state is LeaseState.EXPIRED:
+                expired += 1
+            else:
+                released += 1
+        return active, expired, released
+
+    def _publish_projection_caches(
+        self,
+        leases: dict[int, Lease],
+        free: RangeSet,
+        *,
+        lease_projection: tuple[Lease, ...] | None = None,
+        available_projection: tuple[Span, ...] | None = None,
+        state_counts: tuple[int, int, int] | None = None,
+    ) -> None:
+        if leases is self._leases:
+            if lease_projection is not None:
+                self._lease_projection_cache = lease_projection
+            if state_counts is not None:
+                self._state_counts_cache = state_counts
+        if free is self._free and available_projection is not None:
+            self._available_projection_cache = available_projection
 
     @staticmethod
     def _aligned_at_or_after(value: int, alignment: int) -> int:
@@ -386,9 +437,6 @@ class LeasePool:
                 self._commit(staged, staged_free, now)
                 return lease
 
-            # Allocate against a staged RangeSet even when no expiry occurred;
-            # the live free set is untouched until the complete lease record is
-            # ready to commit.
             allocation_free = self._build_free(staged)
             resource = self._select_span(
                 allocation_free,
@@ -539,22 +587,20 @@ class LeasePool:
             return expired
 
     def _diagnostics_at(
-        self, now: int, leases: dict[int, Lease], free: RangeSet
+        self,
+        now: int,
+        available: tuple[Span, ...],
+        state_counts: tuple[int, int, int],
     ) -> LeaseDiagnostics:
-        intervals = free.intervals()
-        states = tuple(lease.state for lease in leases.values())
+        active, expired, released = state_counts
         return LeaseDiagnostics(
             observed_at=now,
             total_capacity=self._domain.measure,
-            available_capacity=sum(
-                interval.end - interval.start for interval in intervals
-            ),
-            largest_available_span=max(
-                (interval.end - interval.start for interval in intervals), default=0
-            ),
-            active_leases=states.count(LeaseState.ACTIVE),
-            expired_leases=states.count(LeaseState.EXPIRED),
-            released_leases=states.count(LeaseState.RELEASED),
+            available_capacity=sum(span.length for span in available),
+            largest_available_span=max((span.length for span in available), default=0),
+            active_leases=active,
+            expired_leases=expired,
+            released_leases=released,
             issued_tokens=self._next_fencing_token - 1,
             next_fencing_token=self._next_fencing_token,
         )
@@ -564,17 +610,27 @@ class LeasePool:
         with self._lock:
             now = self._observe_time()
             staged, free, _ = self._stage_expirations(now)
+            available = self._available_projection(free)
+            counts = self._state_counts(staged)
+            result = self._diagnostics_at(now, available, counts)
             self._commit(staged, free, now)
-            return self._diagnostics_at(now, staged, free)
+            self._publish_projection_caches(
+                staged,
+                free,
+                available_projection=available,
+                state_counts=counts,
+            )
+            return result
 
     def snapshot(self) -> LeasePoolSnapshot:
         """Return an immutable, time-consistent observable snapshot."""
         with self._lock:
             now = self._observe_time()
             staged, free, _ = self._stage_expirations(now)
-            leases = tuple(sorted(staged.values(), key=lambda lease: lease.token))
-            available = tuple(interval.span for interval in free.intervals())
-            diagnostics = self._diagnostics_at(now, staged, free)
+            leases = self._lease_projection(staged)
+            available = self._available_projection(free)
+            counts = self._state_counts(staged)
+            diagnostics = self._diagnostics_at(now, available, counts)
             result = LeasePoolSnapshot(
                 now,
                 self._pool_id,
@@ -584,6 +640,13 @@ class LeasePool:
                 diagnostics,
             )
             self._commit(staged, free, now)
+            self._publish_projection_caches(
+                staged,
+                free,
+                lease_projection=leases,
+                available_projection=available,
+                state_counts=counts,
+            )
             return result
 
     def checkpoint(self) -> LeasePoolCheckpoint:
@@ -591,10 +654,11 @@ class LeasePool:
         with self._lock:
             now = self._observe_time()
             staged, free, _ = self._stage_expirations(now)
+            leases = self._lease_projection(staged)
             result = LeasePoolCheckpoint(
                 pool_id=self._pool_id,
                 allowed_spans=self._domain.spans,
-                leases=tuple(sorted(staged.values(), key=lambda lease: lease.token)),
+                leases=leases,
                 requests=tuple(
                     sorted(self._requests.values(), key=lambda item: item.request_id)
                 ),
@@ -602,7 +666,35 @@ class LeasePool:
                 last_observed_at=now,
             )
             self._commit(staged, free, now)
+            self._publish_projection_caches(
+                staged,
+                free,
+                lease_projection=leases,
+            )
             return result
+
+    def _lookup_fence_lease(self, evidence: Lease) -> Lease:
+        """Validate issued fence evidence without constructing public state."""
+        if not isinstance(evidence, Lease):
+            raise TypeError("evidence must be a Lease")
+        with self._lock:
+            now = self._observe_time()
+            staged, free, _ = self._stage_expirations(now)
+            issued = staged.get(evidence.token)
+            # A public snapshot previously materialized expiry before the
+            # facade rejected missing or altered evidence. Preserve that order.
+            self._commit(staged, free, now)
+            if issued is None:
+                raise InvalidLeaseError("lease token was not issued by this pool")
+            if (
+                issued.pool_id != evidence.pool_id
+                or issued.owner != evidence.owner
+                or issued.resource != evidence.resource
+                or issued.acquired_at != evidence.acquired_at
+                or issued.request_id != evidence.request_id
+            ):
+                raise InvalidLeaseError("lease evidence differs from issued history")
+            return issued
 
     @classmethod
     def from_checkpoint(
@@ -689,6 +781,9 @@ class LeasePool:
         }
         pool._leases = transitioned
         pool._free = pool._build_free(transitioned)
+        pool._lease_projection_cache = None
+        pool._available_projection_cache = None
+        pool._state_counts_cache = None
         return pool
 
 

--- a/treemendous/applications/leasing/_common.py
+++ b/treemendous/applications/leasing/_common.py
@@ -11,7 +11,6 @@ from treemendous.applications._shared.clock import Clock
 from treemendous.applications._shared.leasing import (
     FenceValidator,
     ForeignLeaseError,
-    InvalidLeaseError,
     Lease,
     LeaseDiagnostics,
     LeasePool,
@@ -295,19 +294,7 @@ class PoolGroup:
         pool = self.pool(handle.scope)
         if handle.pool_id != pool.pool_id:
             raise ForeignLeaseError("lease belongs to another pool lineage")
-        issued = next(
-            (lease for lease in pool.snapshot().leases if lease.token == handle.token),
-            None,
-        )
-        if issued is None:
-            raise InvalidLeaseError("lease token was not issued by this pool")
-        if (
-            issued.owner != handle.owner
-            or issued.resource != handle.resource
-            or issued.acquired_at != handle.lease.acquired_at
-            or issued.request_id != handle.lease.request_id
-        ):
-            raise InvalidLeaseError("lease evidence differs from issued history")
+        pool._lookup_fence_lease(handle.lease)
         identity = (handle.pool_id, handle.token)
         return self.fences.validate_fence(
             key,

--- a/treemendous/rangeset.py
+++ b/treemendous/rangeset.py
@@ -211,6 +211,7 @@ class RangeSet:
         )
         self._geometry_cache_valid = True
         self._pending_geometry_update: tuple[bool, Span] | None = None
+        self._snapshot_cache: RangeSnapshot | None = None
         self._payload_segments = staged_payloads
         self._ordered_events = staged_events
 
@@ -315,6 +316,9 @@ class RangeSet:
     def _geometry_intervals(self) -> tuple[IntervalResult, ...]:
         return self._geometry_cache
 
+    def _invalidate_snapshot_cache(self) -> None:
+        self._snapshot_cache = None
+
     def _invalidate_authoritative_geometry_cache(
         self, span: Span, *, adding: bool
     ) -> None:
@@ -331,6 +335,7 @@ class RangeSet:
                     return tuple(self._clone_segments(self._payload_segments))
             if self._authoritative_geometry:
                 if not self._geometry_cache_valid:
+                    self._invalidate_snapshot_cache()
                     pending = self._pending_geometry_update
                     if pending is None:
                         self._geometry_cache = _normalize_geometry(
@@ -567,6 +572,8 @@ class RangeSet:
             self._adapter.release(span.start, span.end)
             self._geometry_cache = committed_geometry
             self._total_free = committed_total
+            if changed:
+                self._invalidate_snapshot_cache()
             if committed_payloads is not None:
                 self._payload_segments = committed_payloads
             if committed_events is not None:
@@ -649,6 +656,8 @@ class RangeSet:
             self._adapter.reserve(span.start, span.end)
             self._geometry_cache = committed_geometry
             self._total_free = committed_total
+            if changed:
+                self._invalidate_snapshot_cache()
             if committed_payloads is not None:
                 self._payload_segments = committed_payloads
             if committed_events is not None:
@@ -802,6 +811,17 @@ class RangeSet:
 
     def snapshot(self) -> RangeSnapshot:
         with self._lock:
+            if self._payload_policy is None:
+                cached = self._snapshot_cache
+                if cached is not None and self._geometry_cache_valid:
+                    return cached
+                snapshot = RangeSnapshot(
+                    self.intervals(),
+                    self._total_free,
+                    self._domain,
+                )
+                self._snapshot_cache = snapshot
+                return snapshot
             return RangeSnapshot(
                 self.intervals(),
                 self._total_free,


### PR DESCRIPTION
## Summary

Runs the six-area performance roadmap as bounded, evidence-gated experiments and lands only the changes that passed their fixed, pre-registered gates. Failed runtime candidates are deleted rather than shipped behind loosened thresholds. Adds concrete `ExactBatchRangeSet` and `BoxIndex` examples, and hardens every experiment verifier against forged evidence.

The canonical stable API (`RangeSet`, `create_range_set`, `BackendRegistry`), exact-batch geometry, payload algebra, atomicity, and all existing gates are unchanged.

## Accepted into the runtime (2)

- **Geometry-only `RangeSnapshot` cache** (`treemendous/rangeset.py`): reuses one immutable snapshot while geometry is unchanged and no payload policy is set; payload-bearing snapshots still clone/detach exactly as before. 40-block confirmation: unchanged N=10 000 upper-95 **0.00057** (≤0.25), cached N=10000/N=1000 median **0.958** (≤1.50), worst write-then-observe upper-95 **1.035** (≤1.10). Scalar-mutation regression vs. immutable baseline: median **0.98** (100 samples).
- **Lease projection caches + O(1) fence lookup** (`treemendous/applications/_shared/leasing.py`, `leasing/_common.py`, Candidate B): direct token lookup with zero public snapshots and zero linear scans; lazy immutable projections invalidated on publication. 30-block: fence upper-95 **0.177**, repeated-snapshot N=8192 upper-95 **0.266** (both ≤0.50).

## Rejected and removed (deletion, not gate-weakening)

| Area | Result | Reason |
|---|---|---|
| `RangeSet.mutate_many` transaction (E2) | REJECTED | B16/N1000 upper-95 >1.07 per payload, 23× with no payload; `BackendAdapter` has no atomic state-replacement primitive. No method/protocol/export added. |
| Segmented COW native storage (E3) | REJECTED | Wins large-N (N=100k/B16 local <0.60×) but tuned one-block fast path still gives N64/B16 upper-95 **1.116 > 1.10**. Runtime fully reverted to vector storage. |
| Concrete-engine backend injection (E5) | REJECTED | `cpp_boundary` confirmed faster, but current-default `py_boundary` upper-95 hit **1.125** on `pool_group` (≤1.10 default-stability gate). No injection retained. |
| Lease Candidate D (authoritative free-delta) | REJECTED | N8192/N2048 normalized time **3.7×** (≤2×). Reverted. |
| Adaptive `BoxIndex` for RadioSpectrum (E6) | REJECTED | Projection wins narrow queries (0.80–0.91×) but retained memory **1.30–1.37×** (≤1.25×) and broad queries regress to 1.24–1.38×. Runtime stays linear `BoxIndex(2)`. |

## New executable examples

- ExactBatch: `atomic_memory_map_updates`, `atomic_partition_availability_updates`, `genomic_mask_batch_updates`
- BoxIndex: `warehouse_space_time_reservations` (3D), `video_region_timeline_overlap` (3D), `robot_volume_time_conflicts` (4D)

All are registered in `examples/README.md` and executed from an unrelated CWD by `tests/docs/test_readme.py`.

## Diagnostic evidence (informative only)

- **Exact-batch application matrix** (180 cells): `ExactBatchRangeSet` beats scalar `cpp_boundary` replay from B=1 at N≤1000 across all shapes, but **loses at N=10 000** (1.1–3.6×) — the O(N) full-state copy E3 tried and failed to remove.
- **Segmented-storage rejection** is durably reproducible from a tracked patch (`tests/performance/experiments/fixtures/exact_batch_segmented_tuned.patch`) plus an archived triplet under `docs/evidence/experiments/`, bound by source/binary/patch SHA-256 and verifiable offline (`just verify-exact-batch-storage-archive`).

## Verifier hardening

Every experiment verifier rejects fabricated runtime/build/backend provenance, bool/int and int/float coercion, duplicate keys, non-canonical JSON, and relabeled/duplicated matrix rows. The snapshot benchmark's order-confounded pooled analysis was replaced with pre-registered balanced AB/BA blocks and whole-block bootstrap.

## Boundaries preserved

- No compatibility façade, deprecated alias, silent fallback, or weakened exact result.
- Experiment code lives only under `tests/performance/experiments/`; no stable package API, ABI, or gate changed.
- Explicit backend/index/guard qualification errors are never caught to select a fallback.

## Validation

- `just check` (layout, scenarios, Ruff, format, mypy, full pytest + coverage, packaging/docs, bytecode) passed locally.
- Focused experiment suites: 166 passed; snapshot-cache + lease-publication + exact-batch suites green.
- All 12 tracked examples and both README quickstarts execute from an unrelated CWD.
- Durable archive verifier, snapshot/lease/application-backend generators, and their strict verifiers round-trip.

Experiment matrices are machine-specific diagnostics; accepted-runtime decisions rest on the fixed gates above, not on any single headline number.
