### PR TITLE
refactor: dedup the reentrant-mutation guard message

### DIFF
--- a/treemendous/rangeset.py
+++ b/treemendous/rangeset.py
@@ -32,6 +32,8 @@ from treemendous.policies import (
 
 _MISSING = object()
 
+_REENTRANT_MUTATION_MESSAGE = "reentrant mutation on the same RangeSet is not allowed"
+
 
 class _NoOpLock:
     """Lock sentinel that performs no synchronization.
@@ -641,9 +643,7 @@ class RangeSet:
                 self._lock.acquire()
             try:
                 if self._authoritative_mutation_active:
-                    raise RuntimeError(
-                        "reentrant mutation on the same RangeSet is not allowed"
-                    )
+                    raise RuntimeError(_REENTRANT_MUTATION_MESSAGE)
                 self._authoritative_mutation_active = True
                 try:
                     result = native_release(span.start, span.end)
@@ -717,9 +717,7 @@ class RangeSet:
                 self._lock.acquire()
             try:
                 if self._authoritative_mutation_active:
-                    raise RuntimeError(
-                        "reentrant mutation on the same RangeSet is not allowed"
-                    )
+                    raise RuntimeError(_REENTRANT_MUTATION_MESSAGE)
                 self._authoritative_mutation_active = True
                 try:
                     result = native_reserve(span.start, span.end, require_covered)
@@ -818,9 +816,7 @@ class RangeSet:
             self._lock.acquire()
         try:
             if self._authoritative_mutation_active:
-                raise RuntimeError(
-                    "reentrant mutation on the same RangeSet is not allowed"
-                )
+                raise RuntimeError(_REENTRANT_MUTATION_MESSAGE)
             self._authoritative_mutation_active = True
             try:
                 if scalar_release is not None:
@@ -859,9 +855,7 @@ class RangeSet:
             self._lock.acquire()
         try:
             if self._authoritative_mutation_active:
-                raise RuntimeError(
-                    "reentrant mutation on the same RangeSet is not allowed"
-                )
+                raise RuntimeError(_REENTRANT_MUTATION_MESSAGE)
             self._authoritative_mutation_active = True
             try:
                 if scalar_reserve is not None:
@@ -981,9 +975,7 @@ class RangeSet:
                 )
             with self._lock:
                 if self._authoritative_mutation_active:
-                    raise RuntimeError(
-                        "reentrant mutation on the same RangeSet is not allowed"
-                    )
+                    raise RuntimeError(_REENTRANT_MUTATION_MESSAGE)
                 self._authoritative_mutation_active = True
                 try:
                     result = self._adapter.allocate(not_before, length, not_after)


### PR DESCRIPTION
## Summary

Code cleanup / style / deduplication pass over the perf work landed in #19 and #20.

After a full audit of the session's additions, the only safe, no-coupling, no-perf-impact duplication worth removing was the reentrant-mutation guard message, repeated verbatim at all five reentrancy-guard sites. It is now a single module constant `_REENTRANT_MUTATION_MESSAGE`. The message is built only on the error path, so the hot path is unchanged (scalar unsynchronized still ~4.6–5.0 M ops/s).

## Deliberately left as-is (with rationale)

The audit found that most apparent duplication is intentional and justified; consolidating it would add cost or risk for no real benefit:

- **Hot-path lock + reentrancy-guard scaffolding** (repeated across the four collapsed `add`/`discard`/`release`/`reserve` authoritative paths). Factoring it into a context manager re-introduces the `with` `__enter__`/`__exit__` calls that #20 measured as the dominant per-op cost; a plain helper or decorator adds an equivalent call frame. The duplication is the measured price of the ~5 M ops/s scalar path and is documented in the code.
- **Per-experiment evidence verifiers** (`_gate`, `_provenance`, `verify_artifacts`, `render_markdown`, `_git_metadata`, `run_matrix` — each with a distinct implementation per file). These encode each experiment's own schema, gates, and provenance and are intentionally self-contained for tamper resistance.
- **Shared pure primitives** (`_percentile`, `_checksum`, `_reject_*`, `_bootstrap`). Only `_percentile` is byte-identical, and its four copies live in three different packages (`tests/performance/experiments/`, `tests/performance/`, and `scripts/`). Extracting it would couple a standalone CI verifier script to the tests package — worse than an eight-line pure function. The remaining variants differ in error-message text that tamper tests match on, so unifying them risks those tests for no shipped-code benefit.

## Validation

- Full suite: 1402 passed, 21 skipped (no regressions).
- Ruff check + format clean; `mypy treemendous` clean; `git diff --check` clean.
- Hot-path perf sanity check confirms the scalar mutation throughput is unchanged.
