### PR TITLE
Release v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ for discovery and qualification details.
 - [Canonical API](https://github.com/josephjohncox/TreeMendous/blob/main/docs/api.md)
 - [Performance](https://github.com/josephjohncox/TreeMendous/blob/main/docs/performance.md)
 - [Examples](https://github.com/josephjohncox/TreeMendous/blob/main/examples/README.md)
-- [Release notes](https://github.com/josephjohncox/TreeMendous/blob/main/docs/releases/1.1.1.md)
+- [Release notes](https://github.com/josephjohncox/TreeMendous/blob/main/docs/releases/1.2.0.md)
 
 ## Development
 

--- a/docs/releases/1.2.0.md
+++ b/docs/releases/1.2.0.md
@@ -1,0 +1,76 @@
+# Tree-Mendous 1.2.0
+
+A compatible feature release. It adds a faster native `RangeSet` mutation
+surface with a caller-selectable locking level, plus behavior-preserving
+snapshot and lease caching. The stable `1.0.0`, `1.1.0`, and `1.1.1` APIs are
+unchanged and existing applications require no migration.
+
+## Selectable locking level
+
+`RangeSet`, `create_range_set`, and `BackendRegistry.create` accept a new
+`synchronized` keyword.
+
+- `synchronized=True` (the default) keeps the reentrant internal lock and full
+  thread-safety, including snapshot/mutation consistency.
+- `synchronized=False` performs no internal synchronization: the reentrancy
+  guard still functions, but the caller alone owns cross-thread safety and
+  snapshot/mutation consistency. Choose it only under a caller-owned locking
+  discipline or confirmed single-threaded use. `RangeSet.synchronized` reports
+  the selected level.
+
+## Fully-native scalar mutators
+
+`RangeSet` gains two geometry-only scalar mutators that build no
+`MutationResult`:
+
+- `release(span) -> int` — free semantics, the scalar counterpart of `add`.
+- `reserve(span, *, require_covered=False) -> int` — occupy semantics, the
+  scalar counterpart of `discard`; a not-fully-covered strict reserve is a `0`
+  no-op.
+
+Both return only the changed length and are exactly geometry-consistent with
+`add`/`discard`. They require an authoritative geometry-only range set without a
+payload policy and raise `ValueError` rather than falling back silently.
+
+## Faster `add`/`discard`
+
+On the authoritative `cpp_boundary` path, `add`/`discard` now build their
+`MutationResult` through validation-free native constructors for coordinates the
+backend has already validated, and call cached bound native mutators directly,
+removing the adapter wrapper frame and a per-operation `isinstance` check. The
+returned `MutationResult`, `Span`, and `IntervalResult` values are unchanged.
+
+Scoped hot-path evidence on `cpp_boundary` (Apple M5 Max, macOS 26.5.1, CPython
+3.12.7, timing public mutation calls only): `add`/`discard` about 1.5–1.7M
+ops/s, the scalar `release`/`reserve` about 4.3M ops/s synchronized and about
+5.0M ops/s unsynchronized, against a raw-native floor near 7.9M ops/s. See
+[docs/performance.md](../performance.md); this is scoped evidence for one
+interface family and workload, not a universal claim.
+
+## Backend, protocol, and native surface
+
+- `BackendAdapter` exposes `supports_scalar_delta`, `release_delta_length`, and
+  `reserve_delta_length`.
+- `RangeSetProtocol` gains `release` and `reserve`.
+- The C++ `IntervalManager` exposes `release_delta_length` and
+  `reserve_delta_length` returning the changed length, and builds its delta
+  results without re-validating already-validated `int64` geometry. A
+  construction-time probe verifies an authoritative backend's delta contract and
+  fails closed otherwise.
+
+## Behavior-preserving performance
+
+- Geometry-only `RangeSet.snapshot()` reuses one immutable snapshot while the
+  geometry is unchanged and re-materializes after any changed mutation.
+  Payload-bearing snapshots keep their clone-and-detach behavior.
+- The shared lease pool caches lazy immutable lease/availability projections and
+  validates fences through an O(1) token lookup, removing repeated free-state
+  rebuilds and public-snapshot scans in the leasing engines.
+
+## Compatibility
+
+Every addition is compatible. `add`, `discard`, `MutationResult`, `Span`, and
+`IntervalResult` retain their exact semantics and types. `synchronized=False` is
+opt-in with a documented single-threaded or externally-synchronized contract.
+The `treemendous.exact_batch` module and the experimental multidimensional
+indexes are unchanged.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -16,7 +16,11 @@ Earlier factory, manager, protocol, compatibility, and raw-backend exports were
 removed rather than retained as shims. Version `1.1.0` compatibly adds the
 contained `treemendous.exact_batch` API without root exports, backend
 integration, or protocol integration. Version `1.1.1` is a documentation and
-packaging-metadata patch; it does not change either stable API.
+packaging-metadata patch; it does not change either stable API. Version `1.2.0`
+compatibly adds a faster native `RangeSet` mutation surface — a selectable
+`synchronized` locking level and the fully-native scalar `release`/`reserve`
+mutators — plus behavior-preserving snapshot and lease caching. The stable
+`1.0.0` and `1.1.0` APIs are unchanged.
 
 ## Pre-release checks
 
@@ -96,7 +100,7 @@ Install the published wheel in a clean environment and exercise the public API:
 
 ```bash
 python -m venv /tmp/treemendous-release-check
-/tmp/treemendous-release-check/bin/python -m pip install treemendous==1.1.1
+/tmp/treemendous-release-check/bin/python -m pip install treemendous==1.2.0
 (cd /tmp && /tmp/treemendous-release-check/bin/python - <<'PY'
 from treemendous import Span, create_range_set
 from treemendous.exact_batch import BatchMutation, ExactBatchRangeSet, MutationOpcode

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "treemendous"
-version = "1.1.1"
+version = "1.2.0"
 description = "Exact integer range sets with Python/C++ backends, atomic native batches, experimental multidimensional indexes, and 50 application engines."
 authors = [{ name = "Joseph Cox", email = "joseph@codensity.io" }]
 license = "BSD-3-Clause"

--- a/tests/docs/test_readme.py
+++ b/tests/docs/test_readme.py
@@ -133,7 +133,7 @@ def test_maintained_relative_links_resolve() -> None:
 
 def test_installed_version_matches_project_metadata() -> None:
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())
-    assert project["project"]["version"] == "1.1.1"
+    assert project["project"]["version"] == "1.2.0"
     assert version("treemendous") == project["project"]["version"]
 
 
@@ -204,7 +204,7 @@ def test_release_tag_contract_tracks_the_releasable_major_version() -> None:
     assert workflow.count("persist-credentials: false") == 5
     assert workflow.count("enable-cache: false") == 4
     assert "baseline-ref: fdb4efd5f407717c8e18b94e6f4c21cbfb8e5daa" in workflow
-    assert 'version = "1.1.1"' in (ROOT / "pyproject.toml").read_text()
+    assert 'version = "1.2.0"' in (ROOT / "pyproject.toml").read_text()
 
 
 def test_release_artifact_jobs_run_unsplit_strict_twine_checks_before_upload() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1276,7 +1276,7 @@ wheels = [
 
 [[package]]
 name = "treemendous"
-version = "1.1.1"
+version = "1.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "sortedcontainers" },


### PR DESCRIPTION
## Summary

Release `1.2.0` — a compatible feature release cutting the perf work merged in #19/#20/#21. Bumps `pyproject.toml` to `1.2.0`, regenerates `uv.lock`, adds `docs/releases/1.2.0.md`, points the README release-notes link at it, extends the versioning/post-release docs, and moves the pinned version contracts (`test_installed_version_matches_project_metadata`, `test_release_tag_contract_tracks_the_releasable_major_version`) to `1.2.0`.

The stable `1.0.0`/`1.1.0`/`1.1.1` APIs are unchanged; existing applications require no migration.

## What ships in 1.2.0

- **Selectable locking** — `synchronized=` on `RangeSet` / `create_range_set` / `BackendRegistry.create` (+ `RangeSet.synchronized`). Default `True` keeps full thread-safety; `False` opts out of internal synchronization under a caller-owned contract.
- **Fully-native scalar mutators** — `RangeSet.release(span) -> int` and `reserve(span, *, require_covered=False) -> int`, returning only the changed length, geometry-consistent with `add`/`discard`, guarded to authoritative geometry-only sets (no silent fallback).
- **Faster `add`/`discard`** — validation-free native result construction and cached bound native mutators on the `cpp_boundary` path; `MutationResult`/`Span`/`IntervalResult` unchanged.
- **New surface** — `BackendAdapter.supports_scalar_delta`/`release_delta_length`/`reserve_delta_length`; `RangeSetProtocol.release`/`.reserve`; native `IntervalManager.release_delta_length`/`reserve_delta_length`.
- **Behavior-preserving perf** — geometry-only snapshot cache; lease projection + O(1) fence-lookup caches.

Scoped `cpp_boundary` evidence (Apple M5 Max): scalar `release`/`reserve` ~4.3M/s synchronized, ~5.0M/s unsynchronized; `add`/`discard` ~1.5–1.7M/s; raw-native floor ~7.9M/s (was ~0.9M/s for 1.1.1 `add`/`discard`). Not a universal claim — see `docs/performance.md`.

## Pre-release gate (run locally on this branch)

- `uv lock --check` clean; ruff check + format clean; `mypy treemendous` clean.
- `tests/docs` + `tests/packaging/test_artifact_policy.py`: 73 passed (version/notes/link contracts updated).
- `uv build` → wheel + sdist; `scripts.verify_artifact_contents dist` rc=0 (`docs/releases/1.2.0.md` present in sdist); `twine check --strict` PASSED for wheel and sdist.
- Full suite on the same tree earlier: 1402 passed, 21 skipped.

## Publish

On merge, publish a GitHub Release with tag `v1.2.0` targeting the merge commit. The `release: published` workflow re-audits, builds all platform wheels + sdist, runs isolated wheel/sdist smokes and `twine check --strict`, runs the exact-batch evidence against the immutable pre-promotion commit, and publishes once via the single OIDC trusted publisher.
